### PR TITLE
Better Atom detection

### DIFF
--- a/lib/feedzirra/parser/atom.rb
+++ b/lib/feedzirra/parser/atom.rb
@@ -19,7 +19,7 @@ module Feedzirra
       elements :entry, :as => :entries, :class => AtomEntry
 
       def self.able_to_parse?(xml) #:nodoc:
-        xml =~ /(Atom)|(#{Regexp.escape("http://purl.org/atom")})/
+        xml =~ /\<feed[^\>]+xmlns=[\"|\'](http:\/\/www\.w3\.org\/2005\/Atom|http:\/\/purl\.org\/atom\/ns\#)[\"|\'][^\>]*\>/
       end
       
       def url

--- a/spec/feedzirra/feed_spec.rb
+++ b/spec/feedzirra/feed_spec.rb
@@ -107,7 +107,7 @@ describe Feedzirra::Feed do
   describe "when adding feed types" do
     it "should prioritize added types over the built in ones" do
       feed_text = "Atom asdf"
-      Feedzirra::Parser::Atom.should be_able_to_parse(feed_text)
+      Feedzirra::Parser::Atom.stub!(:able_to_parse?).and_return(true)
       new_feed_type = Class.new do
         def self.able_to_parse?(val)
           true


### PR DESCRIPTION
The regex that Feedzirra was using for detecting Atom feeds was a bit too loose and HTML pages that declare an Atom feed in their first 2000 characters would get parsed as Atom (example: http://bur-ii.livejournal.com/ and many other LJ's).

I've made the regex more strict: it now matches on a valid-looking <feed> element, one which uses the W3C or purl.org xmlns declaration.
