### PR TITLE
http header search for Content-Encoding is case-sensitive

### DIFF
--- a/lib/feedzirra/feed.rb
+++ b/lib/feedzirra/feed.rb
@@ -143,7 +143,7 @@ module Feedzirra
     # === Returns
     # A decoded string of XML.
     def self.decode_content(c)
-      if c.header_str.match(/Content-Encoding: gzip/)
+      if c.header_str.match(/Content-Encoding: gzip/i)
         begin
           gz =  Zlib::GzipReader.new(StringIO.new(c.body_str))
           xml = gz.read
@@ -152,7 +152,7 @@ module Feedzirra
           # Maybe this is not gzipped?
           xml = c.body_str
         end
-      elsif c.header_str.match(/Content-Encoding: deflate/)
+      elsif c.header_str.match(/Content-Encoding: deflate/i)
         xml = Zlib::Inflate.inflate(c.body_str)
       else
         xml = c.body_str


### PR DESCRIPTION
Sites can return their Content-Encoding header string back as "Content-encoding" or "content-encoding".  When this happens, decode_content in feed.rb will neither gunzip nor inflate (in the cases of gzip or deflate, respectively) and the compressed body will be incorrectly read as plain text.

The fix is to match against the header string with a case-insensitive search.  Please note that there is no correct casing to "content-encoding" as the HTTP/1.1 RFC 2616 states that these fields are case-insensitive.

Thank you!
