### PR TITLE
Avoid "undefined method `httpdate'"

### DIFF
--- a/lib/feedzirra/feed.rb
+++ b/lib/feedzirra/feed.rb
@@ -261,7 +261,9 @@ module Feedzirra
     def self.add_feed_to_multi(multi, feed, feed_queue, responses, options) 
       easy = Curl::Easy.new(feed.feed_url) do |curl|
         curl.headers["User-Agent"]        = (options[:user_agent] || USER_AGENT)
-        curl.headers["If-Modified-Since"] = feed.last_modified.httpdate if feed.last_modified
+        if feed.last_modified
+          curl.headers["If-Modified-Since"] = feed.last_modified.is_a?(String) ? Time.parse(feed.last_modified).httpdate : feed.last_modified.httpdate
+        end
         curl.headers["If-None-Match"]     = feed.etag if feed.etag
         curl.userpwd = options[:http_authentication].join(':') if options.has_key?(:http_authentication)
         curl.follow_location = true


### PR DESCRIPTION
See [this issue](https://github.com/pauldix/feedzirra/issues#issue/30) for discussion. Sometimes, in `add_feed_to_multi`, `feed.last_modified` is a String instead of a Time object. This patch checks if it is a string, and parses it if it is.
