### PR TITLE
parse link elements in AtomFeedBurnerEntry

### DIFF
--- a/lib/feedzirra/parser/atom_feed_burner_entry.rb
+++ b/lib/feedzirra/parser/atom_feed_burner_entry.rb
@@ -28,6 +28,11 @@ module Feedzirra
       element :updated
       element :modified, :as => :updated
       elements :category, :as => :categories, :value => :term
+      elements :link, :as => :links, :value => :href
+
+      def url
+        @url || links.first
+      end
     end
 
   end


### PR DESCRIPTION
If an Atom feed containing feedburner extensions doesn't have a `feedburner:origLink`, then we should use `atom:link` in the same way that AtomEntry does.

An example of a feed like this is http://feeds.simonwillison.net/swn-everything
