### PR TITLE
Allow activesupport from 3.1.x

### DIFF
--- a/feedzirra.gemspec
+++ b/feedzirra.gemspec
@@ -26,11 +26,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sax-machine',   ['~> 0.0.20']
   s.add_runtime_dependency 'curb',          ['~> 0.7.15']
   s.add_runtime_dependency 'builder',       ['~> 3.0.0']
-  s.add_runtime_dependency 'activesupport', ['~> 3.0.8']
+  s.add_runtime_dependency 'activesupport', ['>= 3.0.8']
   s.add_runtime_dependency 'loofah',        ['~> 1.0.0']
   s.add_runtime_dependency 'rdoc',          ['~> 3.8']
   s.add_runtime_dependency 'rake',          ['>= 0.9.2']
-  s.add_runtime_dependency 'i18n',          ['~> 0.5.0']
+  s.add_runtime_dependency 'i18n',          ['>= 0.5.0']
 
   s.add_development_dependency 'rspec',     ['~> 2.6.0']
 end

--- a/lib/feedzirra.rb
+++ b/lib/feedzirra.rb
@@ -6,7 +6,6 @@ require 'uri'
 
 require 'active_support/basic_object'
 require 'active_support/core_ext/module'
-require 'active_support/core_ext/kernel'
 require 'active_support/core_ext/object'
 require 'active_support/time'
 


### PR DESCRIPTION
This will allow Feedzirra to work with Rails 3.1.0.rc5 (and hopefully Rails 3.1.0). All specs pass with this code.
