### PR TITLE
Added support for :if_modified_since option

### DIFF
--- a/lib/feedzirra/feed.rb
+++ b/lib/feedzirra/feed.rb
@@ -262,6 +262,7 @@ module Feedzirra
       easy = Curl::Easy.new(feed.feed_url) do |curl|
         curl.headers["User-Agent"]        = (options[:user_agent] || USER_AGENT)
         curl.headers["If-Modified-Since"] = feed.last_modified.httpdate if feed.last_modified
+        curl.headers["If-Modified-Since"] = options[:if_modified_since] if options[:if_modified_since] && (!feed.last_modified || (Time.parse(options[:if_modified_since].to_s) > feed.last_modified))
         curl.headers["If-None-Match"]     = feed.etag if feed.etag
         curl.userpwd = options[:http_authentication].join(':') if options.has_key?(:http_authentication)
         curl.follow_location = true

--- a/spec/feedzirra/feed_spec.rb
+++ b/spec/feedzirra/feed_spec.rb
@@ -395,7 +395,13 @@ describe Feedzirra::Feed do
         @easy_curl.headers["User-Agent"].should == Feedzirra::Feed::USER_AGENT
       end
 
-      it "should set if modified since as an option if passed"
+      it "should set if modified since as an option if passed" do
+        modified_time = Time.parse("Wed, 28 Jan 2009 04:10:32 GMT")
+        Feedzirra::Feed.add_feed_to_multi(@multi, @feed, [], {}, {:if_modified_since => modified_time})
+        modified_time.should be > @feed.last_modified
+        
+        @easy_curl.headers["If-Modified-Since"].should == modified_time
+      end
       
       it 'should set follow location to true' do
         @easy_curl.should_receive(:follow_location=).with(true)
@@ -509,6 +515,14 @@ describe Feedzirra::Feed do
       it 'should slice the feeds into groups of thirty for processing'
       it "should return a feed object if a single feed is passed in"
       it "should return an return an array of feed objects if multiple feeds are passed in"
+      
+      it "should set if modified since as an option if passed" do
+        modified_time = Time.parse("Wed, 28 Jan 2009 04:10:32 GMT")
+        Feedzirra::Feed.should_receive(:add_url_to_multi).with(anything, anything, anything, anything, {:if_modified_since => modified_time}).any_number_of_times
+        
+        @feed = Feedzirra::Feed.fetch_and_parse(sample_feedburner_atom_feed, {:if_modified_since => modified_time})
+      end
+      
     end
 
     describe "#decode_content" do


### PR DESCRIPTION
I used this for a job a couple of years ago and forgot to send the pull request back upstream.  It adds support for passing a : if_modified_since header to help limit RSS pulls.  I'm not using this anymore and am cleaning up some stale repos I have, but didn't want this work to be lost if you wanted to include it.
