### PR TITLE
Update Nokogiri dependency

### DIFF
--- a/feedzirra.gemspec
+++ b/feedzirra.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'nokogiri',      ['>= 1.4.4']
   s.add_runtime_dependency 'sax-machine',   ['~> 0.1.0']
   s.add_runtime_dependency 'curb',          ['~> 0.7.15']
-  s.add_runtime_dependency 'builder',       ['~> 2.1.2']
+  s.add_runtime_dependency 'builder',       ['>= 2.1.2']
   s.add_runtime_dependency 'activesupport', ['>= 3.0.8']
   s.add_runtime_dependency 'loofah',        ['~> 1.2.0']
   s.add_runtime_dependency 'rdoc',          ['~> 3.8']


### PR DESCRIPTION
Nokogiri is up to 1.5.0 now and all the specs pass with it.

Cheers
