### PR TITLE
Optimistic Rails requirement for ~> 3.1

### DIFF
--- a/feedzirra.gemspec
+++ b/feedzirra.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sax-machine',   ['~> 0.1.0']
   s.add_runtime_dependency 'curb',          ['~> 0.7.15']
   s.add_runtime_dependency 'builder',       ['>= 2.1.2']
-  s.add_runtime_dependency 'activesupport', ['~> 3.1.1']
+  s.add_runtime_dependency 'activesupport', ['~> 3.1']
   s.add_runtime_dependency 'loofah',        ['~> 1.2.0']
   s.add_runtime_dependency 'rdoc',          ['~> 3.8']
   s.add_runtime_dependency 'rake',          ['>= 0.8.7']

--- a/lib/feedzirra.rb
+++ b/lib/feedzirra.rb
@@ -4,6 +4,7 @@ require 'sax-machine'
 require 'loofah'
 require 'uri'
 
+require 'active_support'
 require 'active_support/basic_object'
 require 'active_support/core_ext/module'
 require 'active_support/core_ext/object'


### PR DESCRIPTION
In Issue #91, a bug was noted regarding upgrading dependencies to include ActiveSupport ~> 3.2; this pull request resolves this issue.

Check out https://github.com/rails/rails/commit/3d03c7982982fd7dda45df9d1973f2696860088b. The implication is that ActiveSupport needs to be required in order `ActiveSupport::Deprecation` to load correctly, or to manually require the module itself.

This pull request is one such possible fix. It's likely safe as per the autoloading of modules in ActiveSupport.
