### PR TITLE
Cookie support for Curb.

### DIFF
--- a/lib/feedzirra/feed.rb
+++ b/lib/feedzirra/feed.rb
@@ -123,6 +123,9 @@ module Feedzirra
     def self.setup_easy curl, options
       curl.headers["Accept-encoding"]   = 'gzip, deflate' if options.has_key?(:compress)
       curl.headers["User-Agent"]        = (options[:user_agent] || USER_AGENT)
+      curl.enable_cookies               = options[:enable_cookies] if options.has_key?(:enable_cookies)
+      curl.cookiefile                   = options[:cookiefile] if options.has_key?(:cookiefile)
+      curl.cookies                      = options[:cookies] if options.has_key?(:cookies)
 
       curl.userpwd = options[:http_authentication].join(':') if options.has_key?(:http_authentication)
       curl.proxy_url = options[:proxy_url] if options.has_key?(:proxy_url)


### PR DESCRIPTION
I've added curl.cookie support in the form either passing a cookie in as an option or a compatible cookie-jar file. Tested with Pulling cookies from authentication (Mechanize) and putting into a Feed object. Works! Handy addition to the codebase, especially for sites that might require an authenticated cookie in order to view a page.
