### PR TITLE
Upgrade curb to 0.8.0

### DIFF
--- a/feedzirra.gemspec
+++ b/feedzirra.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'nokogiri',      ['>= 1.4.4']
   s.add_runtime_dependency 'sax-machine',   ['~> 0.1.0']
-  s.add_runtime_dependency 'curb',          ['~> 0.7.15']
+  s.add_runtime_dependency 'curb',          ['~> 0.8.0']
   s.add_runtime_dependency 'builder',       ['>= 2.1.2']
   s.add_runtime_dependency 'activesupport', ['~> 3.1.1']
   s.add_runtime_dependency 'loofah',        ['~> 1.2.0']


### PR DESCRIPTION
Are there any known reasons not to upgrade to the latest version of curb? I am having dependency conflicts with newer code that breaks with 0.7.15.
