### PR TITLE
Fix iTunes Parser

### DIFF
--- a/lib/feedzirra/feed.rb
+++ b/lib/feedzirra/feed.rb
@@ -44,7 +44,7 @@ module Feedzirra
     # === Returns
     # A array of class names.
     def self.feed_classes
-      @feed_classes ||= [Feedzirra::Parser::RSSFeedBurner, Feedzirra::Parser::RSS, Feedzirra::Parser::GoogleDocsAtom, Feedzirra::Parser::AtomFeedBurner, Feedzirra::Parser::Atom, Feedzirra::Parser::ITunesRSS]
+      @feed_classes ||= [Feedzirra::Parser::ITunesRSS, Feedzirra::Parser::RSSFeedBurner, Feedzirra::Parser::RSS, Feedzirra::Parser::GoogleDocsAtom, Feedzirra::Parser::AtomFeedBurner, Feedzirra::Parser::Atom]
     end
     
     # Makes all registered feeds types look for the passed in element to parse.

--- a/spec/feedzirra/feed_spec.rb
+++ b/spec/feedzirra/feed_spec.rb
@@ -68,14 +68,10 @@ describe Feedzirra::Feed do
         feed.entries.size.should == 5
       end      
 
-      it "should parse an itunes feed as a standard RSS feed" do
+      it "should parse an itunes feed" do
         feed = Feedzirra::Feed.parse(sample_itunes_feed)
         feed.title.should == "All About Everything"
         feed.entries.first.published.should == Time.parse_safely("Wed, 15 Jun 2005 19:00:00 GMT")
-        
-        # Since the commit 621957879, iTunes feeds will be parsed as standard RSS, so this
-        # entry should now not have a method for itunes_author.
-        feed.entries.first.should_not respond_to(:itunes_author)
         feed.entries.size.should == 3
       end
     end


### PR DESCRIPTION
There are a few issues with the iTunes feed parser.
- ~~It appears it was deprecated and later reimplemented, but this change [isn't reflected in the specs](https://github.com/pauldix/feedzirra/blob/master/spec/feedzirra/feed_spec.rb#L71-81).~~ 7e23834 and 72a1a01b
- Sub-categories have [never been properly implemented](https://github.com/pauldix/feedzirra/blob/master/lib/feedzirra/parser/itunes_rss.rb#L32-35). See: #78
