### PR TITLE
Remove gorillib as a dependency.

### DIFF
--- a/feedzirra.gemspec
+++ b/feedzirra.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'sax-machine',       '~> 0.1.0'
   s.add_dependency 'curb',              '~> 0.8.0'
   s.add_dependency 'loofah',            '~> 1.2.1'
-  s.add_dependency 'gorillib',          '~> 0.1.9'
 
   s.add_development_dependency 'rspec', '~> 2.10.0'
 end

--- a/lib/feedzirra.rb
+++ b/lib/feedzirra.rb
@@ -3,7 +3,6 @@ require 'curb'
 require 'sax-machine'
 require 'loofah'
 require 'uri'
-require 'gorillib/datetime/parse'
 
 require 'feedzirra/core_ext'
 

--- a/lib/feedzirra/core_ext.rb
+++ b/lib/feedzirra/core_ext.rb
@@ -1,3 +1,3 @@
-Dir["#{File.dirname(__FILE__)}/core_ext/*.rb"].sort.each do |path|
-  require "feedzirra/core_ext/#{File.basename(path, '.rb')}"
-end
+require "feedzirra/core_ext/time"
+require "feedzirra/core_ext/date"
+require "feedzirra/core_ext/string"

--- a/lib/feedzirra/core_ext/time.rb
+++ b/lib/feedzirra/core_ext/time.rb
@@ -1,0 +1,29 @@
+require "time"
+require "date"
+
+class Time
+  # Parse a time string and convert it to UTC without raising errors.
+  # Parses a flattened 14-digit time (YYYYmmddHHMMMSS) as UTC.
+  #
+  # === Parameters
+  # [dt<String or Time>] Time definition to be parsed.
+  #
+  # === Returns
+  # A Time instance in UTC or nil if there were errors while parsing.
+  def self.parse_safely(dt)
+    if dt
+      case
+      when dt.is_a?(Time)
+        dt.utc
+      when dt.respond_to?(:empty?) && dt.empty?
+        nil
+      when dt.to_s =~ /\A\d{14}\z/
+        parse("#{dt.to_s}Z", true)
+      else
+        parse(dt.to_s, true).utc
+      end
+    end
+  rescue StandardError
+    nil
+  end unless method_defined?(:parse_safely)
+end


### PR DESCRIPTION
Gorillib was being required for a single method that was pretty easily
reimplemented internally. Also expanded the meta programming for loading
core extensions.
