### PR TITLE
Feedzirra::Feed.update should return hash for multiple feeds, else feed itself

### DIFF
--- a/lib/feedzirra/feed.rb
+++ b/lib/feedzirra/feed.rb
@@ -247,7 +247,7 @@ module Feedzirra
       end
     
       multi.perform
-      responses.is_a?(Array)? responses.values : responses.values.first
+      feeds.is_a?(Array) ? responses : responses.values.first
     end
     
     # An abstraction for adding a feed by URL to the passed Curb::multi stack.


### PR DESCRIPTION
I saw @fringd and a few others wanted my change merged. Here's a pull request for it.

Proper fix for #70 / #116

Thanks!
