### PR TITLE
Trigger on_failure for 404s

### DIFF
--- a/lib/feedzirra/feed.rb
+++ b/lib/feedzirra/feed.rb
@@ -292,7 +292,19 @@ module Feedzirra
             options[:on_failure].call(url, c.response_code, c.header_str, c.body_str) if options.has_key?(:on_failure)
           end
         end
-        
+
+        #
+        # trigger on_failure for 404s
+        #
+        curl.on_complete do |c|
+          add_url_to_multi(multi, url_queue.shift, url_queue, responses, options) unless url_queue.empty?
+          responses[url] = c.response_code
+
+          if c.response_code == 404 && options.has_key?(:on_failure)
+            options[:on_failure].call(url, c.response_code, c.header_str, c.body_str)
+          end
+        end
+
         curl.on_failure do |c, err|
           add_url_to_multi(multi, url_queue.shift, url_queue, responses, options) unless url_queue.empty?
           responses[url] = c.response_code


### PR DESCRIPTION
Unless I'm mistaken, Curl::Easy doesn't actually trigger on_failure for a 404 response. The docs say that it is thrown only for 50x errors, which matches my personal experience, and I've also seen it echoed here: http://stackoverflow.com/questions/10076465/ruby-curb-callbacks-order

This pull request adds an on_complete handler which checks to see if the request threw a 404, and if it did, it will call the passed in on_failure method.
