### PR TITLE
Fixed order of feed parsers

### DIFF
--- a/lib/feedzirra/feed.rb
+++ b/lib/feedzirra/feed.rb
@@ -44,7 +44,7 @@ module Feedzirra
     # === Returns
     # A array of class names.
     def self.feed_classes
-      @feed_classes ||= [Feedzirra::Parser::RSSFeedBurner, Feedzirra::Parser::RSS, Feedzirra::Parser::GoogleDocsAtom, Feedzirra::Parser::AtomFeedBurner, Feedzirra::Parser::Atom, Feedzirra::Parser::ITunesRSS]
+      @feed_classes ||= [Feedzirra::Parser::RSSFeedBurner, Feedzirra::Parser::GoogleDocsAtom, Feedzirra::Parser::AtomFeedBurner, Feedzirra::Parser::Atom, Feedzirra::Parser::ITunesRSS, Feedzirra::Parser::RSS]
     end
     
     # Makes all registered feeds types look for the passed in element to parse.


### PR DESCRIPTION
The `Feedzirra::Parser::RSS` is less important than other parsers which use `able_to_parse` to determine the type of feed.

Before this fix feedzirra read my iTunes feed with `Feedzirra::Parser::RSS` and I couldn't use some of the fields from iTunes format.
