### PR TITLE
Use Time.parse_safely in Feed.last_modified_from_header.

### DIFF
--- a/lib/feedzirra/feed.rb
+++ b/lib/feedzirra/feed.rb
@@ -376,7 +376,7 @@ module Feedzirra
     # A Time object of the last modified date or nil if it cannot be found in the headers.
     def self.last_modified_from_header(header)
       header =~ /.*Last-Modified:\s(.*)\r/
-      Time.parse($1) if $1
+      Time.parse_safely($1) if $1
     end
   end
 end


### PR DESCRIPTION
This helps prevent parse failures when there is a problem with the last modified header. For example if the Last-Modified header is empty like on http://feeds.kottke.org/main.

Looks like most of feedzirra already uses parse_safely for Time parsing.

``` bash
curl -v http://feeds.kottke.org/main
* About to connect() to feeds.kottke.org port 80 (#0)
*   Trying 216.243.171.10...
* connected
* Connected to feeds.kottke.org (216.243.171.10) port 80 (#0)
> GET /main HTTP/1.1
> User-Agent: curl/7.24.0 (x86_64-apple-darwin12.0) libcurl/7.24.0 OpenSSL/0.9.8r zlib/1.2.5
> Host: feeds.kottke.org
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Mon, 19 Nov 2012 04:33:38 GMT
< Server: Apache
< X-Powered-By: PHP/5.3.2-1ubuntu4.18
< Last-Modified: 
< Transfer-Encoding: chunked
< Content-Type: text/xml
< Vary: Accept-Encoding, User-Agent
< 
```
