### PR TITLE
Fix: not getting entire feed on url change

### DIFF
--- a/lib/feedzirra/feed_utilities.rb
+++ b/lib/feedzirra/feed_utilities.rb
@@ -54,19 +54,19 @@ module Feedzirra
       # it's to get around the fact that not all feeds have a published date.
       # however, they're always ordered with the newest one first.
       # So we go through the entries just parsed and insert each one as a new entry
-      # until we get to one that has the same url as the the newest for the feed
+      # until we get to one that has the same id as the the newest for the feed
       return feed.entries if self.entries.length == 0
       latest_entry = self.entries.first
       found_new_entries = []
       feed.entries.each do |entry|
-        break if entry.url == latest_entry.url
+        break if entry.id == latest_entry.id
         found_new_entries << entry
       end
       found_new_entries
     end
 
     def existing_entry?(test_entry)
-      entries.any? { |entry| entry.url == test_entry.url }
+      entries.any? { |entry| entry.id == test_entry.id }
     end
   end
 end


### PR DESCRIPTION
If the first entry of a feed changes its url feed.new_entries will
then contain all entries of the feed, even old, already seen ones.

find_new_entries_for only looked for the url of the first entry from the
last run to determine when the list of already seen entries starts. Not
finding the url, it did add all entries to new_entries.

Instead of using url, using id (which has a fallback to url) fixes this
bug.
