### PR TITLE
Added activesupport as a dependency

### DIFF
--- a/feedzirra.gemspec
+++ b/feedzirra.gemspec
@@ -16,13 +16,14 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ['lib']
-  
+
   s.platform = Gem::Platform::RUBY
 
   s.add_dependency 'nokogiri',          '~> 1.5.3'
   s.add_dependency 'sax-machine',       '~> 0.2.0.rc1'
   s.add_dependency 'curb',              '~> 0.8.0'
   s.add_dependency 'loofah',            '~> 1.2.1'
+  s.add_dependency 'activesupport',     '~> 3.2.1'
 
   s.add_development_dependency 'rspec', '~> 2.10.0'
 end


### PR DESCRIPTION
In Rails 3.2.12 I got the following error:

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    feedzirra (= 0.1.3) ruby depends on
      activesupport (~> 3.1.1) ruby

    rails (~> 3.2.12) ruby depends on
      activesupport (3.2.12)
```
