### PR TITLE
CURL SSL Version option.

### DIFF
--- a/lib/feedzirra/feed.rb
+++ b/lib/feedzirra/feed.rb
@@ -128,6 +128,8 @@ module Feedzirra
       curl.max_redirects = options[:max_redirects] if options[:max_redirects]
       curl.timeout = options[:timeout] if options[:timeout]
       curl.ssl_verify_host = options[:ssl_verify_host] if options.has_key?(:ssl_verify_host)
+      curl.ssl_version = options[:ssl_version] if options.has_key?(:ssl_version)
+      curl.ssl_verify_peer = options[:ssl_verify_peer] if options.has_key?(:ssl_verify_peer)
 
       curl.follow_location = true
     end


### PR DESCRIPTION
I had a problem connecting to a feed and I found that the problem was with tomcat and a good way to fix it was changing the ssl_version.

http://blog.55minutes.com/2012/05/tls-error-with-ruby-client-and-tomcat-server/

I added the parameter the ssl_version parameter option to be set in curl.

Also I added the verify_peer parameter. I know it is not recommeded for production enviroments but it is very usefull in development environments.

Thanks a lot fot this gem. :) Great job! :)
