### PR TITLE
Add closed captioned and order tags from Apple's podcast spec

### DIFF
--- a/lib/feedzirra/parser/itunes_rss_item.rb
+++ b/lib/feedzirra/parser/itunes_rss_item.rb
@@ -23,6 +23,7 @@ module Feedzirra
       element :"itunes:subtitle", :as => :itunes_subtitle
       element :"itunes:isClosedCaptioned", :as => :itunes_closed_captioned
       element :"itunes:order", :as => :itunes_order
+      element :"itunes:image", :as => :itunes_image
       # If summary is not present, use the description tag
       element :"itunes:summary", :as => :itunes_summary
       element :enclosure, :value => :length, :as => :enclosure_length


### PR DESCRIPTION
These fields are allowed in an iTunes podcast feed. Here's a link to the documentation for them.

http://www.apple.com/itunes/podcasts/specs.html#isClosedCaptioned
http://www.apple.com/itunes/podcasts/specs.html#order
