### PR TITLE
Bumping nokogiri to 1.6.0

### DIFF
--- a/feedzirra.gemspec
+++ b/feedzirra.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
 
   s.add_dependency 'nokogiri',          '~> 1.6.0'
-  s.add_dependency 'sax-machine',       '~> 0.2.0.rc1', git: 'git@github.com:mje113/sax-machine.git'
+  s.add_dependency 'sax-machine',       '~> 0.2.0.rc1'
   s.add_dependency 'curb',              '~> 0.8.1'
   s.add_dependency 'loofah',            '~> 1.2.1'
 


### PR DESCRIPTION
The same change will need to be made in sax-machine (pull request already opened there).
