### PR TITLE
Rename ItunesRssItem#guid to #entry_id to follow all other item types

### DIFF
--- a/lib/feedzirra/parser/itunes_rss_item.rb
+++ b/lib/feedzirra/parser/itunes_rss_item.rb
@@ -1,5 +1,5 @@
 module Feedzirra
-  
+
   module Parser
     # iTunes extensions to the standard RSS2.0 item
     # Source: http://www.apple.com/itunes/whatson/podcasts/specs.html
@@ -8,7 +8,7 @@ module Feedzirra
       include FeedEntryUtilities
 
       element :author
-      element :guid
+      element :guid, :as => :entry_id
       element :title
       element :link, :as => :url
       element :description, :as => :summary
@@ -28,5 +28,5 @@ module Feedzirra
       element :enclosure, :value => :url, :as => :enclosure_url
     end
   end
-  
+
 end

--- a/spec/feedzirra/parser/itunes_rss_item_spec.rb
+++ b/spec/feedzirra/parser/itunes_rss_item_spec.rb
@@ -6,43 +6,43 @@ describe Feedzirra::Parser::ITunesRSSItem do
     # but this is actually how it should work. You would never just pass entry xml straight to the ITunesRssItem
     @item = Feedzirra::Parser::ITunesRSS.parse(sample_itunes_feed).entries.first
   end
-  
+
   it "should parse the title" do
     @item.title.should == "Shake Shake Shake Your Spices"
   end
-  
+
   it "should parse the author" do
     @item.itunes_author.should == "John Doe"
-  end  
+  end
 
   it "should parse the subtitle" do
     @item.itunes_subtitle.should == "A short primer on table spices"
-  end  
+  end
 
   it "should parse the summary" do
     @item.itunes_summary.should == "This week we talk about salt and pepper shakers, comparing and contrasting pour rates, construction materials, and overall aesthetics. Come and join the party!"
-  end  
+  end
 
   it "should parse the enclosure" do
     @item.enclosure_length.should == "8727310"
     @item.enclosure_type.should == "audio/x-m4a"
     @item.enclosure_url.should == "http://example.com/podcasts/everything/AllAboutEverythingEpisode3.m4a"
-  end  
+  end
 
-  it "should parse the guid" do
-    @item.guid.should == "http://example.com/podcasts/archive/aae20050615.m4a"
-  end  
+  it "should parse the guid as id" do
+    @item.id.should == "http://example.com/podcasts/archive/aae20050615.m4a"
+  end
 
   it "should parse the published date" do
     @item.published.should == Time.parse_safely("Wed Jun 15 19:00:00 UTC 2005")
-  end  
+  end
 
   it "should parse the duration" do
     @item.itunes_duration.should == "7:04"
-  end  
+  end
 
   it "should parse the keywords" do
     @item.itunes_keywords.should == "salt, pepper, shaker, exciting"
-  end  
+  end
 
 end


### PR DESCRIPTION
I'd say that all of them should have the same method to fetch the id, no?

Sorry for the newline changes, I was having some trouble committing it. It makes some noise in the diff. :)
