### PR TITLE
don't sanitize content if it doesn't exist.

### DIFF
--- a/lib/feedzirra/feed_entry_utilities.rb
+++ b/lib/feedzirra/feed_entry_utilities.rb
@@ -40,7 +40,7 @@ module Feedzirra
       self.title.sanitize! if self.title
       self.author.sanitize! if self.author
       self.summary.sanitize! if self.summary
-      self.content.sanitize! if self.content
+      self.content.sanitize! if self.respond_to?(:content) && self.content
       self.image.sanitize! if self.image
     end
 


### PR DESCRIPTION
this raised NoMethodError: undefined method `content' when parsing Feedzirra::Parser::ITunesRSSItem.

fixes #173
