### PR TITLE
Use dc:identifier as entry_id

### DIFF
--- a/lib/feedzirra/parser/rss_entry.rb
+++ b/lib/feedzirra/parser/rss_entry.rb
@@ -29,6 +29,7 @@ module Feedzirra
       elements :category, :as => :categories
       
       element :guid, :as => :entry_id     
+      element :"dc:identifier", :as => :entry_id
     end
 
   end


### PR DESCRIPTION
Fixes #181

I don't know Ruby or this library very well, but I think this will fix feedbin/support#287
