### PR TITLE
Strip leading whitespace before parsing.

### DIFF
--- a/lib/feedzirra/feed.rb
+++ b/lib/feedzirra/feed.rb
@@ -284,6 +284,7 @@ module Feedzirra
 
         curl.on_success do |c|
           xml = decode_content(c)
+          xml = xml.lstrip if xml.respond_to?(:lstrip)
           klass = determine_feed_parser_for_xml(xml)
 
           if klass


### PR DESCRIPTION
Nokogiri throws an XML parse error if the xml declaration is not at start of the document.

There's a number of feeds out there that are otherwise valid, but have some leading whitespace
causing Feedzirra to fail.
