### PR TITLE
iTunes element support for FeedBurner Feeds

### DIFF
--- a/lib/feedzirra/parser/rss_feed_burner_entry.rb
+++ b/lib/feedzirra/parser/rss_feed_burner_entry.rb
@@ -32,6 +32,19 @@ module Feedzirra
 
         element :guid, :as => :entry_id
 
+        # If author is not present use author tag on the item
+        element :"itunes:author", :as => :itunes_author
+        element :"itunes:block", :as => :itunes_block
+        element :"itunes:duration", :as => :itunes_duration
+        element :"itunes:explicit", :as => :itunes_explicit
+        element :"itunes:keywords", :as => :itunes_keywords
+        element :"itunes:subtitle", :as => :itunes_subtitle
+        # If summary is not present, use the description tag
+        element :"itunes:summary", :as => :itunes_summary
+        element :enclosure, :value => :length, :as => :enclosure_length
+        element :enclosure, :value => :type, :as => :enclosure_type
+        element :enclosure, :value => :url, :as => :enclosure_url
+
         def url
           @url || @link
         end


### PR DESCRIPTION
FeedBurner feeds can also have iTunes elements for example the [TED videocasts](http://feeds.feedburner.com/TedtalksHD?format=xml).
