### PR TITLE
Changed on_success/on_failure example to use curly braces instead of brackets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ updated_feeds = Feedzirra::Feed.update(feeds.values)
 
 # defining custom behavior on failure or success. note that a return status of 304 (not updated) will call the on_success handler
 feed = Feedzirra::Feed.fetch_and_parse("http://feeds.feedburner.com/PaulDixExplainsNothing",
-	:on_success => lambda {|feed| puts feed.title },
+	:on_success => lambda {|url, feed| puts feed.title },
 	:on_failure => lambda {|url, response_code, response_header, response_body| puts response_body })
 
 # if a collection was passed into fetch_and_parse, the handlers will be called for each one


### PR DESCRIPTION
I think there is a syntax error in the readme file. Lambdas are using brackets instead of curly braces. I simply copy/pasted the example from the linked gist to the repo's readme file..
