### PR TITLE
Bugfix for parsing dates that are ISO 8601 with milliseconds

### DIFF
--- a/lib/feedzirra/core_ext/time.rb
+++ b/lib/feedzirra/core_ext/time.rb
@@ -17,6 +17,8 @@ class Time
         dt.utc
       when dt.respond_to?(:empty?) && dt.empty?
         nil
+      when dt.respond_to?(:to_datetime)
+        dt.to_datetime.utc
       when dt.to_s =~ /\A\d{14}\z/
         parse("#{dt.to_s}Z", true)
       else

--- a/spec/feedzirra/feed_entry_utilities_spec.rb
+++ b/spec/feedzirra/feed_entry_utilities_spec.rb
@@ -13,6 +13,12 @@ describe Feedzirra::FeedUtilities do
       time.class.should == Time
       time.should == Time.parse_safely("Wed Feb 20 18:05:00 UTC 2008")
     end
+
+    it "should parse a ISO 8601 with milliseconds into Time" do
+      time = @klass.new.parse_datetime("2013-09-17T08:20:13.931-04:00")
+      time.class.should == Time
+      time.should == Time.parse_safely("Tue Sep 17 12:20:13 UTC 2013")
+    end
   end
 
   describe "sanitizing" do


### PR DESCRIPTION
I have noticed that some wordpress sites do not properly give an ISO 8601 timestring, as they include the milliseconds.  I am sending a patch that addresses this along with a test.
