### PR TITLE
be a new entry if feed not have entry id and only difference is a url

### DIFF
--- a/lib/feedzirra/feed_utilities.rb
+++ b/lib/feedzirra/feed_utilities.rb
@@ -86,7 +86,11 @@ module Feedzirra
       latest_entry = self.entries.first
       found_new_entries = []
       feed.entries.each do |entry|
-        break if entry.entry_id == latest_entry.entry_id || entry.url == latest_entry.url
+        if entry.entry_id.nil? && latest_entry.entry_id.nil?
+          break if entry.url == latest_entry.url
+        else
+          break if entry.entry_id == latest_entry.entry_id || entry.url == latest_entry.url
+        end
         found_new_entries << entry
       end
       found_new_entries


### PR DESCRIPTION
Since the feed that I've tried did not exist entry_id, new_entries did not pick up.
As a solution, if entry_id does not exist, If there is a difference in the url, it's treated as a new entry How about?

I'm sorry if you are hard to understand my English. 
