### PR TITLE
Moved lstrip before preprocess.

### DIFF
--- a/lib/feedjira/feed_utilities.rb
+++ b/lib/feedjira/feed_utilities.rb
@@ -11,8 +11,9 @@ module Feedjira
 
     module ClassMethods
       def parse(xml, &block)
+        xml = xml.lstrip
         xml = preprocess(xml) if preprocess_xml
-        super xml.lstrip, &block
+        super xml, &block
       end
 
       def preprocess(xml)


### PR DESCRIPTION
Leading whitespace causes parse errors. If preprocess is called on a feed that has leading whitespace it can result in a missing parsed feed.
