### PR TITLE
fix parsing of itunes:new-feed-url

### DIFF
--- a/lib/feedjira/parser/itunes_rss.rb
+++ b/lib/feedjira/parser/itunes_rss.rb
@@ -24,7 +24,7 @@ module Feedjira
       element :"itunes:explicit", :as => :itunes_explicit
       element :"itunes:keywords", :as => :itunes_keywords
       # New URL for the podcast feed
-      element :"itunes:new-feed-url", :as => :itunes_new_feed_url
+      element :"itunes:new_feed_url", :as => :itunes_new_feed_url
       element :"itunes:subtitle", :as => :itunes_subtitle
       # If summary is not present, use the description tag
       element :"itunes:summary", :as => :itunes_summary

--- a/spec/feedjira/parser/itunes_rss_spec.rb
+++ b/spec/feedjira/parser/itunes_rss_spec.rb
@@ -54,5 +54,9 @@ describe Feedjira::Parser::ITunesRSS do
     it "should parse entries" do
       @feed.entries.size.should == 3
     end
+
+    it "should parse the new-feed-url" do
+      @feed.itunes_new_feed_url.should == "http://example.com/new.xml"
+    end
   end
 end

--- a/spec/sample_feeds/itunes.xml
+++ b/spec/sample_feeds/itunes.xml
@@ -8,6 +8,7 @@
 <language>en-us</language>
 <copyright>&#x2117; &amp; &#xA9; 2005 John Doe &amp; Family</copyright>
 <itunes:subtitle>A show about everything</itunes:subtitle>
+<itunes:new-feed-url>http://example.com/new.xml</itunes:new-feed-url>
 <itunes:author>John Doe</itunes:author>
 <itunes:summary>All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our Podcast in the iTunes Music Store</itunes:summary>
 <description>All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our Podcast in the iTunes Music Store</description>


### PR DESCRIPTION
Feedjira was not recognizing the `itunes:new-feed-url` in the `ITunesRSS` parser. It looks like SAXMachine converts dashes in XML tags to underscores. At least I think that's what was happening...

Providing a fix for it, with specs.
