### PR TITLE
Bump loofah gem to 2.0.0

### DIFF
--- a/feedjira.gemspec
+++ b/feedjira.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'sax-machine', '~> 0.2.1'
   s.add_dependency 'curb',        '~> 0.8.1'
-  s.add_dependency 'loofah',      '~> 1.2.1'
+  s.add_dependency 'loofah',      '~> 2.0.0'
 
   s.add_development_dependency 'rspec', '~> 2.14.0'
 end

--- a/lib/feedjira/version.rb
+++ b/lib/feedjira/version.rb
@@ -1,3 +1,3 @@
 module Feedjira
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
Per #215.

I just bumped `loofah` to 2.0.0 and ran the test suite. All green.

I went ahead and bumped the gem version as well, hope that's okay :)
