### PR TITLE
Enclosure support for atom feeds

### DIFF
--- a/lib/feedjira/feed_entry_utilities.rb
+++ b/lib/feedjira/feed_entry_utilities.rb
@@ -11,7 +11,7 @@ module Feedjira
       begin
         DateTime.parse(string).feed_utils_to_gm_time
       rescue
-        warn "Did fail to parse date #{string.inspect}"
+        #warn "Did fail to parse date #{string.inspect}"
         begin
           DateTime.strptime(string.downcase, '%m/%d/%Y %H:%M:%s %p')
         rescue

--- a/lib/feedjira/feed_entry_utilities.rb
+++ b/lib/feedjira/feed_entry_utilities.rb
@@ -11,11 +11,11 @@ module Feedjira
       begin
         DateTime.parse(string).feed_utils_to_gm_time
       rescue
-        warn "Failed to parse date #{string.inspect}"
+        warn "Did fail to parse date #{string.inspect}"
         begin
           DateTime.strptime(string.downcase, '%m/%d/%Y %H:%M:%s %p')
         rescue
-          warn "Failed to parse date with alt format #{string.inspect}"
+          warn "Did fail to parse date with alt format #{string.inspect}"
         end
       end
     end

--- a/lib/feedjira/feed_entry_utilities.rb
+++ b/lib/feedjira/feed_entry_utilities.rb
@@ -11,11 +11,10 @@ module Feedjira
       begin
         DateTime.parse(string).feed_utils_to_gm_time
       rescue
-        #warn "Did fail to parse date #{string.inspect}"
         begin
           DateTime.strptime(string.downcase, '%m/%d/%Y %H:%M:%s %p')
         rescue
-          warn "Did fail to parse date with alt format #{string.inspect}"
+          warn "Failed to parse date #{string.inspect}"
         end
       end
     end

--- a/lib/feedjira/feed_entry_utilities.rb
+++ b/lib/feedjira/feed_entry_utilities.rb
@@ -12,7 +12,11 @@ module Feedjira
         DateTime.parse(string).feed_utils_to_gm_time
       rescue
         warn "Failed to parse date #{string.inspect}"
-        nil
+        begin
+          DateTime.strptime(string.downcase, '%m/%d/%Y %H:%M:%s %p')
+        rescue
+          warn "Failed to parse date with alt format #{string.inspect}"
+        end
       end
     end
 

--- a/lib/feedjira/parser/atom_entry.rb
+++ b/lib/feedjira/parser/atom_entry.rb
@@ -6,6 +6,8 @@ module Feedjira
       include SAXMachine
       include FeedEntryUtilities
 
+      attr_accessor :enclosure_url, :enclosure_type, :enclosure_length
+
       element :title
       element :link, :as => :url, :value => :href, :with => {:type => "text/html", :rel => "alternate"}
       element :name, :as => :author
@@ -23,10 +25,26 @@ module Feedjira
       element :modified, :as => :updated
       elements :category, :as => :categories, :value => :term
       elements :link, :as => :links, :value => :href
+      elements :link, :as => :enclosures, :value => :href, :with => {:rel => "enclosure"}
+      elements :link, :as => :enclosure_types, :value => :type, :with => {:rel => "enclosure"}
+      elements :link, :as => :enclosure_lengths, :value => :type, :with => {:rel => "enclosure"}
 
       def url
         @url ||= links.first
       end
+
+      def enclosure_url
+        @enclosure_url ||= enclosures.first
+      end
+
+      def enclosure_type
+        @enclosure_type ||= enclosures.first
+      end
+
+      def enclosure_length
+        @enclosure_type ||= enclosures.first
+      end
+
     end
 
   end


### PR DESCRIPTION
I came across a [podcast feed](http://feeds.feedburner.com/SlaughterFilm) using Atom, not the usual RSS format. So the normal iTunes parser didn't support it and I wanted a way to extract the enclosure from an Atom feed. The enclosure was included as a `link` with `rel=enclosure`, but the Atom parser strips out rel and other attributes as it just puts the links in an array of URLs. So I made this to extract the first link of type enclosure.

One caveat here is I also made the extracted properties editable using `attr_accessor`. This is because it's sometimes necessary to "massage" feed data after it's been populated from the raw feed. Normally, SaxMachine's `element(s)` declarations will automatically make the field editable; the `attr_accessor` here is emulating the same behaviour.
