### PR TITLE
Don't unescape escaped HTML inside XHTML content node.

### DIFF
--- a/lib/feedjira/preprocessor.rb
+++ b/lib/feedjira/preprocessor.rb
@@ -22,7 +22,7 @@ module Feedjira
     end
 
     def raw_html(node)
-      CGI.unescape_html node.search('./div').inner_html
+      node.search('./div').inner_html
     end
 
     def doc

--- a/spec/feedjira/preprocessor_spec.rb
+++ b/spec/feedjira/preprocessor_spec.rb
@@ -18,4 +18,10 @@ describe Feedjira::Preprocessor do
     expect(escaped.split("\n")[16]).to match /&lt;b&gt;XHTML&lt;\/b&gt;/ #summary
     expect(escaped.split("\n")[26]).to match /&lt;p&gt;$/ #content
   end
+
+  it 'leaves escaped html within pre tag' do
+    processor = Feedjira::Preprocessor.new sample_atom_xhtml_with_escpaed_html_in_pre_tag_feed
+    escaped = processor.to_xml
+    expect(escaped.split("\n")[7]).to eq "        &lt;pre&gt;&amp;lt;b&amp;gt;test&amp;lt;b&amp;gt;&lt;/pre&gt;"
+  end
 end

--- a/spec/sample_feeds.rb
+++ b/spec/sample_feeds.rb
@@ -19,7 +19,8 @@ module SampleFeeds
     sample_wfw_feed: "PaulDixExplainsNothingWFW.xml",
     sample_google_docs_list_feed: "GoogleDocsList.xml",
     sample_feed_burner_atom_xhtml_feed: "FeedBurnerXHTML.xml",
-    sample_duplicate_content_atom_feed: "DuplicateContentAtomFeed.xml"
+    sample_duplicate_content_atom_feed: "DuplicateContentAtomFeed.xml",
+    sample_atom_xhtml_with_escpaed_html_in_pre_tag_feed: "AtomEscapedHTMLInPreTag.xml"
   }
 
   FEEDS.each do |method, filename|

--- a/spec/sample_feeds/AtomEscapedHTMLInPreTag.xml
+++ b/spec/sample_feeds/AtomEscapedHTMLInPreTag.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title type="html">Test feed</title>
+  <entry>
+    <title type="text">Test entry</title>
+    <content type="xhtml">
+      <div xmlns="http://www.w3.org/1999/xhtml">
+        <p>This is escaped html:</p>
+        <pre>&lt;b&gt;test&lt;b&gt;</pre>
+      </div>
+    </content>
+  </entry>
+</feed>


### PR DESCRIPTION
Fixes #270 
