### PR TITLE
Custom faraday object

### DIFF
--- a/lib/feedjira/feed.rb
+++ b/lib/feedjira/feed.rb
@@ -62,13 +62,8 @@ module Feedjira
       end
     end
 
-<<<<<<< Updated upstream
-    def self.fetch_and_parse(url)
-      response = connection(url).get
-=======
-    def self.fetch_and_parse(url, custom_connection)
-      response = custom_connection ||= connection(url).get
->>>>>>> Stashed changes
+    def self.fetch_and_parse(url, custom_connection = nil )
+      response = custom_connection ? custom_connection.get(url) : connection(url).get
       raise FetchFailure.new("Fetch failed - #{response.status}") unless response.success?
       xml = response.body
       parser_klass = determine_feed_parser_for_xml xml

--- a/lib/feedjira/feed.rb
+++ b/lib/feedjira/feed.rb
@@ -62,8 +62,13 @@ module Feedjira
       end
     end
 
+<<<<<<< Updated upstream
     def self.fetch_and_parse(url)
       response = connection(url).get
+=======
+    def self.fetch_and_parse(url, custom_connection)
+      response = custom_connection ||= connection(url).get
+>>>>>>> Stashed changes
       raise FetchFailure.new("Fetch failed - #{response.status}") unless response.success?
       xml = response.body
       parser_klass = determine_feed_parser_for_xml xml

--- a/spec/feedjira/feed_spec.rb
+++ b/spec/feedjira/feed_spec.rb
@@ -34,6 +34,21 @@ describe Feedjira::Feed do
       expect(feed.etag).to eq 'a20cd-393e-517c9e38bab40'
       expect(feed.last_modified).to eq 'Fri, 05 Jun 2015 18:59:17 GMT'
     end
+
+    it 'accepts faraday object' do
+      url = 'http://feedjira.com/blog/feed.xml'
+      faraday_object = Faraday.new do |conn|
+        conn.use FaradayMiddleware::FollowRedirects, limit: 3
+        conn.adapter :net_http
+      end
+      feed = Feedjira::Feed.fetch_and_parse(url, faraday_object)
+
+      expect(feed.class).to eq Feedjira::Parser::Atom
+      expect(feed.entries.count).to eq 4
+      expect(feed.feed_url).to eq url
+      expect(feed.etag).to be_truthy
+      expect(feed.last_modified).to be_truthy
+    end
   end
 
   describe "#add_common_feed_element" do

--- a/spec/feedjira/feed_spec.rb
+++ b/spec/feedjira/feed_spec.rb
@@ -29,7 +29,7 @@ describe Feedjira::Feed do
       feed = Feedjira::Feed.fetch_and_parse url
 
       expect(feed.class).to eq Feedjira::Parser::Atom
-      expect(feed.entries.count).to be > 0
+      expect(feed.entries.count).to eq 4
       expect(feed.feed_url).to eq url
       expect(feed.etag).to eq 'a20cd-393e-517c9e38bab40'
       expect(feed.last_modified).to eq 'Fri, 05 Jun 2015 18:59:17 GMT'
@@ -44,7 +44,7 @@ describe Feedjira::Feed do
       feed = Feedjira::Feed.fetch_and_parse(url, faraday_object)
 
       expect(feed.class).to eq Feedjira::Parser::Atom
-      expect(feed.entries.count).to eq 4
+      expect(feed.entries.count).to be > 0
       expect(feed.feed_url).to eq url
       expect(feed.etag).to be_truthy
       expect(feed.last_modified).to be_truthy

--- a/spec/feedjira/feed_spec.rb
+++ b/spec/feedjira/feed_spec.rb
@@ -29,7 +29,7 @@ describe Feedjira::Feed do
       feed = Feedjira::Feed.fetch_and_parse url
 
       expect(feed.class).to eq Feedjira::Parser::Atom
-      expect(feed.entries.count).to eq 4
+      expect(feed.entries.count).to be > 0
       expect(feed.feed_url).to eq url
       expect(feed.etag).to eq 'a20cd-393e-517c9e38bab40'
       expect(feed.last_modified).to eq 'Fri, 05 Jun 2015 18:59:17 GMT'


### PR DESCRIPTION
This still does not address the options issue as the time out options are passed in when calling the get method and is applied per request inside of fetch_and_parse, however this will allow you customize your connection. 

Also changed etag and last_modified to be true rather than a physical value since those change.  I suppose we can look to see if its a string or date?  But for now I thought that might be good enough for the tests.
