### PR TITLE
modified the podcast order to prevent the condition where a feed burn…

### DIFF
--- a/lib/feedjira/feed.rb
+++ b/lib/feedjira/feed.rb
@@ -23,11 +23,11 @@ module Feedjira
 
     def self.feed_classes
       @feed_classes ||= [
+        Feedjira::Parser::ITunesRSS,
         Feedjira::Parser::RSSFeedBurner,
         Feedjira::Parser::GoogleDocsAtom,
         Feedjira::Parser::AtomFeedBurner,
         Feedjira::Parser::Atom,
-        Feedjira::Parser::ITunesRSS,
         Feedjira::Parser::RSS
       ]
     end


### PR DESCRIPTION
There is a condition with feedburner podcast rss feeds that prevents them from being parsed by the intunes parser. To fix this, I re moved the itunes parser to the first element in the feed_classes array. This way when if there is a podcast on feedburner, the able_to_parse? in itunes_rss will always match regardless of where it is hosted.