### PR TITLE
Enhanced DateTime Handling for supporting non ISO 8601 DateTime Strings

### DIFF
--- a/lib/feedjira.rb
+++ b/lib/feedjira.rb
@@ -5,6 +5,7 @@ require 'sax-machine'
 require 'loofah'
 
 require 'feedjira/core_ext'
+require 'feedjira/date_time_utilities'
 require 'feedjira/feed_entry_utilities'
 require 'feedjira/feed_utilities'
 require 'feedjira/feed'

--- a/lib/feedjira/date_time_utilities.rb
+++ b/lib/feedjira/date_time_utilities.rb
@@ -1,0 +1,59 @@
+module Feedjira
+  module DateTimeUtilities
+
+    # Japanese Symbols are required for strange Date Strings like '水, 31 8 2016 07:37:00 PDT'
+    JAPANESE_SYMBOLS = %w(日 月 火 水 木 金 土).freeze
+
+    # These translations are required for translating abbreviations into english
+    MONTHS_ENGLISH = %w(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec).freeze
+    MONTHS_SPANISH = %w(Ene Feb Mar Abr May Jun Jul Ago Sep Oct Nov Dic).freeze
+
+    # Parse the given string starting with the most common parser (default ruby)
+    # and going over all other available parsers
+    def parse_datetime(string)
+      datetime = DateTime.parse(string) rescue nil
+      datetime = parse_datetime_with_patterns(string) rescue nil if datetime.nil?
+      datetime = parse_datetime_with_language(string) rescue nil if datetime.nil?
+      datetime = datetime.feed_utils_to_gm_time unless datetime.nil?
+      warn "Failed to parse date #{string.inspect}" if datetime.nil?
+      datetime
+    end
+
+    private    
+
+    # Some DateTimes can be converted to valid ISO 8601 datetimes by simply remove unnescessary prefixes
+    def prepare(string)
+      rgx = Regexp.new("^(#{JAPANESE_SYMBOLS.join('|')}),\s")
+      string.gsub(rgx, '')
+    end
+
+    # Instead of using ISO 8601 defaults use different patterns to parse date strings
+    def parse_datetime_with_patterns(string)
+      string = prepare(string)
+      patterns = ["%m/%d/%Y %T %p", "%d %m %Y %T %Z"]
+      patterns.each do |p|
+        begin
+        datetime = DateTime.strptime(string,p)
+        return datetime
+        rescue
+        end
+      end
+      raise "No pattern matched #{string}"
+    end
+
+    def parse_datetime_with_language(string)
+      DateTime.parse(translate(string))
+    end
+
+    # Translate foreign language DateTime strings to english
+    def translate(string)
+      MONTHS_SPANISH.each_with_index do |m,i|
+        rgx = Regexp.new("\s#{m}\s", Regexp::IGNORECASE)
+        if string =~ rgx
+          return string.gsub(rgx, MONTHS_ENGLISH[i])
+        end
+      end
+      raise "No translation found for #{string}"
+    end
+  end
+end

--- a/lib/feedjira/feed.rb
+++ b/lib/feedjira/feed.rb
@@ -72,7 +72,9 @@ module Feedjira
       feed = parse_with parser_klass, xml
       feed.feed_url = url
       feed.etag = response.headers['etag'].to_s.gsub(/"/, '')
-      feed.last_modified = response.headers['last-modified']
+
+      last_modified = response.headers['last-modified']
+      feed.last_modified = DateTime.parse(last_modified).to_time rescue nil
       feed
     end
 

--- a/lib/feedjira/feed_entry_utilities.rb
+++ b/lib/feedjira/feed_entry_utilities.rb
@@ -2,58 +2,10 @@ module Feedjira
   module FeedEntryUtilities
 
     include Enumerable
+    include DateTimeUtilities
 
     def published
       @published ||= @updated
-    end
-
-
-    # FIXME: Create a DateTime utilities method instead
-    def parse_datetime(string)
-      datetime = DateTime.parse(string) rescue nil
-      datetime = parse_datetime_with_patterns(string) rescue nil if datetime.nil?
-      datetime = parse_datetime_with_language(string) rescue nil if datetime.nil?
-      datetime = datetime.feed_utils_to_gm_time unless datetime.nil?
-      warn "Failed to parse date #{string.inspect}" if datetime.nil?
-      datetime
-    end
-
-    JAPANESE_SYMBOLS = %w(日 月 火 水 木 金 土).freeze
-
-    def prepare(string)
-      rgx = Regexp.new("^(#{JAPANESE_SYMBOLS.join('|')}),\s")
-      string.gsub(rgx, '')
-    end
-
-    # Instead of using ISO 8601 defaults use different patterns to parse date strings
-    def parse_datetime_with_patterns(string)
-      string = prepare(string)
-      patterns = ["%m/%d/%Y %T %p", "%d %m %Y %T %Z"]
-      patterns.each do |p|
-        begin
-        datetime = DateTime.strptime(string,p)
-        return datetime
-        rescue
-        end
-      end
-      raise "No pattern matched #{string}"
-    end
-
-    MONTHS_ENGLISH = %w(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec).freeze
-    MONTHS_SPANISH = %w(Ene Feb Mar Abr May Jun Jul Ago Sep Oct Nov Dic).freeze
-
-    def translate(string)
-      MONTHS_SPANISH.each_with_index do |m,i|
-        rgx = Regexp.new("\s#{m}\s", Regexp::IGNORECASE)
-        if string =~ rgx
-          return string.gsub(rgx, MONTHS_ENGLISH[i])
-        end
-      end
-      raise "No translation found for #{string}"
-    end
-
-    def parse_datetime_with_language(string)
-      DateTime.parse(translate(string))
     end
 
     ##

--- a/lib/feedjira/version.rb
+++ b/lib/feedjira/version.rb
@@ -1,3 +1,3 @@
 module Feedjira
-  VERSION = '2.0.1'
+  VERSION = '2.0.0'
 end

--- a/spec/feedjira/date_time_utilities_spec.rb
+++ b/spec/feedjira/date_time_utilities_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Feedjira::FeedUtilities do
+  before(:each) do
+    @klass = Class.new do
+      include Feedjira::DateTimeUtilities
+    end
+  end
+
+  describe "handling dates" do
+    it "should parse an ISO 8601 formatted datetime into Time" do
+      time = @klass.new.parse_datetime("2008-02-20T8:05:00-010:00")
+      expect(time.class).to eq Time
+      expect(time).to eq Time.parse_safely("Wed Feb 20 18:05:00 UTC 2008")
+    end
+
+    it "should parse a ISO 8601 with milliseconds into Time" do
+      time = @klass.new.parse_datetime("2013-09-17T08:20:13.931-04:00")
+      expect(time.class).to eq Time
+      expect(time).to eq Time.parse_safely("Tue Sep 17 12:20:13 UTC 2013")
+    end
+
+    it "should parse a US Format into Time" do
+      time = @klass.new.parse_datetime("8/23/2016 12:29:58 PM")
+      expect(time.class).to eq Time
+      expect(time).to eq Time.parse_safely("Wed Aug 23 12:29:58 UTC 2016")
+    end
+
+    it "should parse a Spanish Format into Time" do
+      time = @klass.new.parse_datetime("Wed, 31 Ago 2016 11:08:22 GMT")
+      expect(time.class).to eq Time
+      expect(time).to eq Time.parse_safely("Wed Aug 31 11:08:22 UTC 2016")
+    end
+
+    it "should parse Format with japanese symbols into Time" do
+      time = @klass.new.parse_datetime("水, 31 8 2016 07:37:00 PDT")
+      expect(time.class).to eq Time
+      expect(time).to eq Time.parse_safely("Wed Aug 31 14:37:00 UTC 2016")
+    end
+  end
+end

--- a/spec/feedjira/feed_entry_utilities_spec.rb
+++ b/spec/feedjira/feed_entry_utilities_spec.rb
@@ -19,6 +19,24 @@ describe Feedjira::FeedUtilities do
       expect(time.class).to eq Time
       expect(time).to eq Time.parse_safely("Tue Sep 17 12:20:13 UTC 2013")
     end
+
+    it "should parse a US Format into Time" do
+      time = @klass.new.parse_datetime("8/23/2016 12:29:58 PM")
+      expect(time.class).to eq Time
+      expect(time).to eq Time.parse_safely("Wed Aug 23 12:29:58 UTC 2016")
+    end
+
+    it "should parse a Spanish Format into Time" do
+      time = @klass.new.parse_datetime("Wed, 31 Ago 2016 11:08:22 GMT")
+      expect(time.class).to eq Time
+      expect(time).to eq Time.parse_safely("Wed Aug 31 11:08:22 UTC 2016")
+    end
+
+    it "should parse Format with japanese symbols into Time" do
+      time = @klass.new.parse_datetime("水, 31 8 2016 07:37:00 PDT")
+      expect(time.class).to eq Time
+      expect(time).to eq Time.parse_safely("Wed Aug 31 14:37:00 UTC 2016")
+    end
   end
 
   describe "sanitizing" do

--- a/spec/feedjira/feed_entry_utilities_spec.rb
+++ b/spec/feedjira/feed_entry_utilities_spec.rb
@@ -7,38 +7,6 @@ describe Feedjira::FeedUtilities do
     end
   end
 
-  describe "handling dates" do
-    it "should parse an ISO 8601 formatted datetime into Time" do
-      time = @klass.new.parse_datetime("2008-02-20T8:05:00-010:00")
-      expect(time.class).to eq Time
-      expect(time).to eq Time.parse_safely("Wed Feb 20 18:05:00 UTC 2008")
-    end
-
-    it "should parse a ISO 8601 with milliseconds into Time" do
-      time = @klass.new.parse_datetime("2013-09-17T08:20:13.931-04:00")
-      expect(time.class).to eq Time
-      expect(time).to eq Time.parse_safely("Tue Sep 17 12:20:13 UTC 2013")
-    end
-
-    it "should parse a US Format into Time" do
-      time = @klass.new.parse_datetime("8/23/2016 12:29:58 PM")
-      expect(time.class).to eq Time
-      expect(time).to eq Time.parse_safely("Wed Aug 23 12:29:58 UTC 2016")
-    end
-
-    it "should parse a Spanish Format into Time" do
-      time = @klass.new.parse_datetime("Wed, 31 Ago 2016 11:08:22 GMT")
-      expect(time.class).to eq Time
-      expect(time).to eq Time.parse_safely("Wed Aug 31 11:08:22 UTC 2016")
-    end
-
-    it "should parse Format with japanese symbols into Time" do
-      time = @klass.new.parse_datetime("水, 31 8 2016 07:37:00 PDT")
-      expect(time.class).to eq Time
-      expect(time).to eq Time.parse_safely("Wed Aug 31 14:37:00 UTC 2016")
-    end
-  end
-
   describe "sanitizing" do
     before(:each) do
       @feed = Feedjira::Feed.parse(sample_atom_feed)


### PR DESCRIPTION
While parsing a lot of foreign feeds I've seen a lot of crazy DateTimes inside these feeds. Because feedjira expects a feed to use ISO 8601 DateTime Format, we would loos these feeds date information. 
In fact, using non ISO 8601 DateTime Format is - in most cases - a violation of the feeds doctype. But I think it is OK to handle these violations, because there are a lot of them.
I've startet with spanish and one japanese example. Maybe I will contribute more handlers in the future.
