### PR TITLE
Properly add JRuby to travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle
+.projections.json
 .ruby-gemset
 .ruby-version
 Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ env:
   matrix:
     - HANDLER="nokogiri"
     - HANDLER="ox"
+
+before_install:
+  - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,11 @@ branches:
     - travis
 
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1
   - 2.2
-  - jruby-19mode
-  - rbx-2
+  - 2.3
+  - jruby
+  - rbx
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 
-bundler_args: --without tools
-
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,13 @@ rvm:
   - rbx
 
 env:
-  matrix:
-    - HANDLER="nokogiri"
-    - HANDLER="ox"
+  - HANDLER=nokogiri
+  - HANDLER=ox
+
+matrix:
+  exclude:
+    - rvm: jruby
+      env: HANDLER=ox
 
 before_install:
   - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
   - HANDLER=ox
 
 matrix:
+  allow_failures:
+    - rvm: jruby
   exclude:
     - rvm: jruby
       env: HANDLER=ox

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ gem 'pry'
 
 group :test do
   gem 'rake'
-  gem 'ox'
+  gem 'ox', platforms: [:mri, :rbx]
 end

--- a/spec/feedjira/feed_spec.rb
+++ b/spec/feedjira/feed_spec.rb
@@ -31,8 +31,8 @@ describe Feedjira::Feed do
       expect(feed.class).to eq Feedjira::Parser::Atom
       expect(feed.entries.count).to eq 4
       expect(feed.feed_url).to eq url
-      expect(feed.etag).to eq 'a20cd-393e-517c9e38bab40'
-      expect(feed.last_modified).to eq 'Fri, 05 Jun 2015 18:59:17 GMT'
+      expect(feed.etag).to eq 'a21c2-393e-518529acc04c0'
+      expect(feed.last_modified).to eq 'Fri, 12 Jun 2015 14:05:47 GMT'
     end
   end
 

--- a/spec/feedjira/parser/atom_feed_burner_entry_spec.rb
+++ b/spec/feedjira/parser/atom_feed_burner_entry_spec.rb
@@ -2,6 +2,7 @@ require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
 
 describe Feedjira::Parser::AtomFeedBurnerEntry do
   before(:each) do
+    Feedjira::Parser::AtomFeedBurner.preprocess_xml = false
     # I don't really like doing it this way because these unit test should only rely on AtomEntry,
     # but this is actually how it should work. You would never just pass entry xml straight to the AtomEnry
     @entry = Feedjira::Parser::AtomFeedBurner.parse(sample_feedburner_atom_feed).entries.first

--- a/spec/feedjira/parser/atom_feed_burner_spec.rb
+++ b/spec/feedjira/parser/atom_feed_burner_spec.rb
@@ -45,6 +45,7 @@ describe Feedjira::Parser::AtomFeedBurner do
     end
 
     it "should parse hub urls" do
+      Feedjira::Parser::AtomFeedBurner.preprocess_xml = false
       feed_with_hub = Feedjira::Parser::AtomFeedBurner.parse(load_sample("TypePadNews.xml"))
       expect(feed_with_hub.hubs.count).to eq 1
     end

--- a/spec/feedjira/parser/rss_feed_burner_entry_spec.rb
+++ b/spec/feedjira/parser/rss_feed_burner_entry_spec.rb
@@ -3,10 +3,10 @@ require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
 
 describe Feedjira::Parser::RSSFeedBurnerEntry do
   before(:each) do
+    Feedjira::Feed.add_common_feed_entry_element("wfw:commentRss", :as => :comment_rss)
     # I don't really like doing it this way because these unit test should only rely on RSSEntry,
     # but this is actually how it should work. You would never just pass entry xml straight to the AtomEnry
     @entry = Feedjira::Parser::RSSFeedBurner.parse(sample_rss_feed_burner_feed).entries.first
-    Feedjira::Feed.add_common_feed_entry_element("wfw:commentRss", :as => :comment_rss)
   end
 
   after(:each) do


### PR DESCRIPTION
Coming back to this project after quite a bit of time and found the project in a bad state.

My initial goal is to get Travis back to a green state and build up from there. To that end, I found and fixed some flickering tests, dropped really old Ruby versions and have allowed JRuby to fail.

You might notice that this PR drops support for Ruby 1.9.3 and 2.0.0, I feel like this is fair given the state of those rubies:

https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/

In fact, with Ruby 2.4 just around the corner, expect to see 2.1 dropped soon too:

https://www.ruby-lang.org/en/news/2016/09/08/ruby-2-4-0-preview2-released/