### PR TITLE
Quick-fix for the timeout issue

### DIFF
--- a/lib/feedjira.rb
+++ b/lib/feedjira.rb
@@ -29,4 +29,5 @@ require 'feedjira/parser/google_docs_atom'
 module Feedjira
   class NoParserAvailable < StandardError; end
   class FetchFailure < StandardError; end
+  class ArgumentError < StandardError; end
 end

--- a/lib/feedjira/feed.rb
+++ b/lib/feedjira/feed.rb
@@ -62,7 +62,7 @@ module Feedjira
       end
     end
 
-    def self.fetch_and_parse(url, timeout)
+    def self.fetch_and_parse(url, timeout = nil)
       response = connection(url, timeout).get
       raise FetchFailure.new("Fetch failed - #{response.status}") unless response.success?
       xml = response.body

--- a/lib/feedjira/feed.rb
+++ b/lib/feedjira/feed.rb
@@ -62,8 +62,8 @@ module Feedjira
       end
     end
 
-    def self.fetch_and_parse(url)
-      response = connection(url).get
+    def self.fetch_and_parse(url, timeout)
+      response = connection(url, timeout).get
       raise FetchFailure.new("Fetch failed - #{response.status}") unless response.success?
       xml = response.body
       parser_klass = determine_feed_parser_for_xml xml
@@ -76,10 +76,11 @@ module Feedjira
       feed
     end
 
-    def self.connection(url)
+    def self.connection(url, timeout)
       Faraday.new(url: url) do |conn|
         conn.use FaradayMiddleware::FollowRedirects, limit: 3
         conn.adapter :net_http
+        conn.options.timeout = timeout if timeout
       end
     end
   end

--- a/lib/feedjira/feed.rb
+++ b/lib/feedjira/feed.rb
@@ -77,6 +77,8 @@ module Feedjira
     end
 
     def self.connection(url, timeout)
+      raise ArgumentError.new("Timeout need to be an integer.") if timeout && !timeout.is_a?(Numeric)
+
       Faraday.new(url: url) do |conn|
         conn.use FaradayMiddleware::FollowRedirects, limit: 3
         conn.adapter :net_http

--- a/spec/feedjira/feed_spec.rb
+++ b/spec/feedjira/feed_spec.rb
@@ -34,6 +34,14 @@ describe Feedjira::Feed do
       expect(feed.etag).to eq 'a21c2-393e-518529acc04c0'
       expect(feed.last_modified).to eq 'Fri, 12 Jun 2015 14:05:47 GMT'
     end
+
+    it 'throws and error when timeout not numeric' do
+      url = 'http://feedjira.com/blog/feed.xml'
+
+      expect {
+        feed = Feedjira::Feed.fetch_and_parse url, "1"
+      }.to raise_error Feedjira::ArgumentError
+    end
   end
 
   describe "#add_common_feed_element" do


### PR DESCRIPTION
Based on #294 and on the proposal of @ajkamel I've created an quick solution for passing in only the timeout parameter. 

I think once other issues will be raised concerning granular options [(discussion in thread)](https://github.com/feedjira/feedjira/issues/294#issuecomment-115413298) of Faraday, we can add them one-by-one.