### PR TITLE
Use JRuby 9000 on Travis

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.1
+
 Documentation:
   Enabled: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - HANDLER=ox
 
 matrix:
+  fast_finish: true
   allow_failures:
     - rvm: jruby
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3
-  - jruby
+  - jruby-9
   - rbx
 
 env:
@@ -14,9 +14,9 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: jruby
+    - rvm: jruby-9
   exclude:
-    - rvm: jruby
+    - rvm: jruby-9
       env: HANDLER=ox
 
 before_install:


### PR DESCRIPTION
When I pulled in #317 I broke the broken JRuby build because I was using an older JRuby. This PR upgrades our JRuby to 9000. While I was at it, I also locked Rubocop to use Ruby 2.1. I upgraded my local clone to use 2.3 and it was making suggestions that would break on older versions.