### PR TITLE
Cache bundler to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 
+cache: bundler
+
 rvm:
   - 2.1
   - 2.2


### PR DESCRIPTION
Per this page:

https://docs.travis-ci.com/user/caching/#Bundler

Caching Bundler is not yet the default behavior.