### PR TITLE
use vcr to stub network requests

### DIFF
--- a/feedjira.gemspec
+++ b/feedjira.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'danger-commit_lint'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '0.43.0'
+  s.add_development_dependency 'vcr', '~> 3.0.3'
 end

--- a/fixtures/vcr_cassettes/fetch_failure.yml
+++ b/fixtures/vcr_cassettes/fetch_failure.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.example.com/feed.xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+  response:
+    status:
+      code: 404
+      message: 
+    headers:
+      cache-control:
+      - max-age=604800
+      content-type:
+      - text/html
+      date:
+      - Mon, 31 Oct 2016 02:29:13 GMT
+      etag:
+      - '"359670651+gzip"'
+      expires:
+      - Mon, 07 Nov 2016 02:29:13 GMT
+      last-modified:
+      - Fri, 09 Aug 2013 23:54:35 GMT
+      server:
+      - ECS (oxr/83C7)
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - HIT
+      x-ec-custom-error:
+      - '1'
+      content-length:
+      - '606'
+      connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
+        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
+        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: \"Open
+        Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n
+        \   div {\n        width: 600px;\n        margin: 5em auto;\n        padding:
+        50px;\n        background-color: #fff;\n        border-radius: 1em;\n    }\n
+        \   a:link, a:visited {\n        color: #38488f;\n        text-decoration:
+        none;\n    }\n    @media (max-width: 700px) {\n        body {\n            background-color:
+        #fff;\n        }\n        div {\n            width: auto;\n            margin:
+        0 auto;\n            border-radius: 0;\n            padding: 1em;\n        }\n
+        \   }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
+        \   <p>This domain is established to be used for illustrative examples in
+        documents. You may use this\n    domain in examples without prior coordination
+        or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
+        information...</a></p>\n</div>\n</body>\n</html>\n"
+    http_version: 
+  recorded_at: Mon, 31 Oct 2016 02:29:13 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/parse_error.yml
+++ b/fixtures/vcr_cassettes/parse_error.yml
@@ -1,0 +1,222 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://feedjira.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Mon, 31 Oct 2016 02:29:13 GMT
+      server:
+      - Apache/2.4.18 (Ubuntu)
+      last-modified:
+      - Fri, 07 Oct 2016 14:50:31 GMT
+      etag:
+      - '"3678-53e47882c0305-gzip"'
+      accept-ranges:
+      - bytes
+      vary:
+      - Accept-Encoding
+      content-length:
+      - '3519'
+      connection:
+      - close
+      content-type:
+      - text/html
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset='utf-8'>
+        <meta content='IE=edge;chrome=1' http-equiv='X-UA-Compatible'>
+        <meta content='width=device-width, initial-scale=.7, maximum-scale=1' name='viewport'>
+        <title>Feedjira</title>
+        <link href="http://fonts.googleapis.com/css?family=Merriweather+Sans:400,300,400italic,700,700italic,300italic" rel="stylesheet" type="text/css" media="screen" />
+        <link href="/css/syntax.css" media="screen" rel="stylesheet" type="text/css" />
+        <link href="/css/style.css" media="screen" rel="stylesheet" type="text/css" />
+        <link rel="alternate" type="application/atom+xml" title="Atom Feed" href="/blog/feed.xml" />
+        </head>
+        <body>
+        <div id='content'>
+        <header>
+        <h1><a href="/">Feedjira</a></h1>
+        </header>
+        <nav>
+        <ul>
+        <li><a href="/">Home</a></li>
+        <li><a href="/blog/">Blog</a></li>
+        <li><a target="_blank" href="https://github.com/feedjira/feedjira">Source</a></li>
+        </ul>
+        </nav>
+        <section><h1>The Feedjira Ruby Gem</h1>
+
+        <p><a href="https://github.com/feedjira/feedjira">Feedjira</a> (formerly Feedzirra) is a Ruby gem for fetching and parsing
+        RSS feeds. Version 2.0 <a href="/blog/2015/06/05/feedjira-two-point-oh.html">was recently released</a>.</p>
+
+        <h2>Getting Started</h2>
+
+        <p>Feedjira is tested with Ruby version 1.9.3 and 2.x so like any Ruby gem, the
+        first step is to install the gem:</p>
+        <pre class="highlight text"><table><tbody><tr><td class="gutter gl"><div class="lineno">1</div></td><td class="code">$ gem install feedjira
+        </td></tr></tbody></table></pre>
+        <p>Or add it to your Gemfile:</p>
+        <pre class="highlight ruby"><table><tbody><tr><td class="gutter gl"><div class="lineno">1</div></td><td class="code"><span class="n">gem</span> <span class="s1">&#39;feedjira&#39;</span>
+        </td></tr></tbody></table></pre>
+        <h2>Fetching and Parsing</h2>
+
+        <p>For many users, the <code>fetch_and_parse</code> method is what they use Feedjira for. This
+        method takes a url and returns a Parser object:</p>
+        <pre class="highlight ruby"><table><tbody><tr><td class="gutter gl"><div class="lineno">1</div><div class="lineno">2</div><div class="lineno">3</div></td><td class="code"><span class="n">url</span> <span class="o">=</span> <span class="s2">&quot;http://feedjira.com/blog/feed.xml&quot;</span>
+        <span class="n">feed</span> <span class="o">=</span> <span class="no">Feedjira</span><span class="o">::</span><span class="no">Feed</span><span class="nf">.fetch_and_parse</span> <span class="n">url</span>
+        <span class="c1"># =&gt; #&lt;Feedjira::Parser::Atom...&gt;</span>
+        </td></tr></tbody></table></pre>
+        <p>These feed objects have both the meta data for a feed and an <code>entries</code>
+        collection that contains all the entries that were found:</p>
+        <pre class="highlight ruby"><table><tbody><tr><td class="gutter gl"><div class="lineno">1</div><div class="lineno">2</div><div class="lineno">3</div><div class="lineno">4</div><div class="lineno">5</div><div class="lineno">6</div></td><td class="code"><span class="n">feed</span><span class="nf">.title</span>
+        <span class="c1"># =&gt; &quot;Feedjira Blog&quot;</span>
+        <span class="n">feed</span><span class="nf">.url</span>
+        <span class="c1"># =&gt; &quot;http://feedjira.com/blog&quot;</span>
+        <span class="n">feed</span><span class="nf">.entries</span> <span class="c1"># returns an array of Entry objects</span>
+        <span class="c1"># =&gt; [&lt;Feedjira::Feed::Entry ...&gt;, &lt;Feedjira::Feed::Entry ...&gt;, ...]</span>
+        </td></tr></tbody></table></pre>
+        <p>These entry objects contain the data parsed from the feed XML:</p>
+        <pre class="highlight ruby"><table><tbody><tr><td class="gutter gl"><div class="lineno">1</div><div class="lineno">2</div><div class="lineno">3</div><div class="lineno">4</div><div class="lineno">5</div></td><td class="code"><span class="n">entry</span> <span class="o">=</span> <span class="n">feed</span><span class="nf">.entries.first</span>
+        <span class="n">entry</span><span class="nf">.title</span>
+        <span class="c1"># =&gt; &quot;Announcing verison 1.0&quot;</span>
+        <span class="n">entry</span><span class="nf">.url</span>
+        <span class="c1"># =&gt; &quot;http://feedjira.com/blog/2014-02-12-announcing-version-10.html&quot;</span>
+        </td></tr></tbody></table></pre>
+        <h2>Just Parsing</h2>
+
+        <p>The parsing functionality of Feedjira has been exposed so that it can be used in
+        isolation:</p>
+        <pre class="highlight ruby"><table><tbody><tr><td class="gutter gl"><div class="lineno">1</div><div class="lineno">2</div><div class="lineno">3</div><div class="lineno">4</div></td><td class="code"><span class="n">xml</span> <span class="o">=</span> <span class="no">Faraday</span><span class="nf">.get</span><span class="p">(</span><span class="n">url</span><span class="p">)</span><span class="nf">.body</span>
+        <span class="n">feed</span> <span class="o">=</span> <span class="no">Feedjira</span><span class="o">::</span><span class="no">Feed</span><span class="nf">.parse</span> <span class="n">xml</span>
+        <span class="n">feed</span><span class="nf">.entries.first.title</span>
+        <span class="c1"># =&gt; &quot;Announcing verison 1.0&quot;</span>
+        </td></tr></tbody></table></pre>
+        <h2>Adding a feed parsing class</h2>
+
+        <p>When determining which parser to use for a given XML document, the following
+        list of parser classes is used:</p>
+
+        <ul>
+        <li><code>Feedjira::Parser::RSSFeedBurner</code></li>
+        <li><code>Feedjira::Parser::GoogleDocsAtom</code></li>
+        <li><code>Feedjira::Parser::AtomFeedBurner</code></li>
+        <li><code>Feedjira::Parser::Atom</code></li>
+        <li><code>Feedjira::Parser::ITunesRSS</code></li>
+        <li><code>Feedjira::Parser::RSS</code></li>
+        </ul>
+
+        <p>You can insert your own parser at the front of this stack by calling
+        <code>add_feed_class</code>, like this:</p>
+        <pre class="highlight ruby"><table><tbody><tr><td class="gutter gl"><div class="lineno">1</div></td><td class="code"><span class="no">Feedjira</span><span class="o">::</span><span class="no">Feed</span><span class="nf">.add_feed_class</span> <span class="no">MyAwesomeParser</span>
+        </td></tr></tbody></table></pre>
+        <p>Now when you <code>fetch_and_parse</code>, <code>MyAwesomeParser</code> will be the first one to get a
+        chance to parse the feed.</p>
+
+        <p>If you have the XML and just want to provide a parser class for one parse, you
+        can specify that using <code>parse_with</code>:</p>
+        <pre class="highlight ruby"><table><tbody><tr><td class="gutter gl"><div class="lineno">1</div></td><td class="code"><span class="no">Feedjira</span><span class="o">::</span><span class="no">Feed</span><span class="nf">.parse_with</span> <span class="no">MyAwesomeParser</span><span class="p">,</span> <span class="n">xml</span>
+        </td></tr></tbody></table></pre>
+        <h2>Adding attributes to all feeds types / all entries types</h2>
+        <pre class="highlight ruby"><table><tbody><tr><td class="gutter gl"><div class="lineno">1</div><div class="lineno">2</div><div class="lineno">3</div><div class="lineno">4</div><div class="lineno">5</div><div class="lineno">6</div><div class="lineno">7</div><div class="lineno">8</div><div class="lineno">9</div><div class="lineno">10</div></td><td class="code"><span class="c1"># Add the generator attribute to all feed types</span>
+        <span class="no">Feedjira</span><span class="o">::</span><span class="no">Feed</span><span class="nf">.add_common_feed_element</span><span class="p">(</span><span class="s1">&#39;generator&#39;</span><span class="p">)</span>
+        <span class="no">Feedjira</span><span class="o">::</span><span class="no">Feed</span><span class="nf">.fetch_and_parse</span><span class="p">(</span><span class="s2">&quot;http://www.pauldix.net/atom.xml&quot;</span><span class="p">)</span><span class="nf">.generator</span> <span class="c1"># =&gt; &#39;TypePad&#39;</span>
+
+        <span class="c1"># Add some GeoRss information</span>
+        <span class="no">Feedjira</span><span class="o">::</span><span class="no">Feed</span><span class="nf">.add_common_feed_entry_element</span><span class="p">(</span><span class="s1">&#39;geo:lat&#39;</span><span class="p">,</span> <span class="ss">:as</span> <span class="o">=&gt;</span> <span class="ss">:lat</span><span class="p">)</span>
+        <span class="no">Feedjira</span><span class="o">::</span><span class="no">Feed</span><span class="nf">.fetch_and_parse</span><span class="p">(</span><span class="s2">&quot;http://www.earthpublisher.com/georss.php&quot;</span><span class="p">)</span><span class="nf">.entries.each</span> <span class="k">do</span> <span class="o">|</span><span class="n">e</span><span class="o">|</span>
+          <span class="nb">p</span> <span class="s2">&quot;lat: #[e.lat}, long: </span><span class="si">#{</span><span class="n">e</span><span class="nf">.long</span><span class="o">]</span><span class="s2">&quot;
+        end
+        </span></td></tr></tbody></table></pre>
+        <h2>Adding attributes to only one class</h2>
+
+        <p>If you want to add attributes for only one class you simply have to declare them
+        in the class</p>
+        <pre class="highlight ruby"><table><tbody><tr><td class="gutter gl"><div class="lineno">1</div><div class="lineno">2</div><div class="lineno">3</div><div class="lineno">4</div><div class="lineno">5</div><div class="lineno">6</div><div class="lineno">7</div><div class="lineno">8</div><div class="lineno">9</div><div class="lineno">10</div><div class="lineno">11</div><div class="lineno">12</div></td><td class="code"><span class="c1"># Add some GeoRss information</span>
+        <span class="nb">require</span> <span class="s1">&#39;lib/feedzirra/parser/rss_entry&#39;</span>
+
+        <span class="k">class </span><span class="nc">Feedjira</span><span class="o">::</span><span class="no">Parser</span><span class="o">::</span><span class="no">RSSEntry</span>
+          <span class="n">element</span> <span class="s1">&#39;geo:lat&#39;</span><span class="p">,</span> <span class="ss">:as</span> <span class="o">=&gt;</span> <span class="ss">:lat</span>
+          <span class="n">element</span> <span class="s1">&#39;geo:long&#39;</span><span class="p">,</span> <span class="ss">:as</span> <span class="o">=&gt;</span> <span class="ss">:long</span>
+        <span class="k">end</span>
+
+        <span class="c1"># Fetch a feed containing GeoRss info and print them</span>
+        <span class="no">Feedjira</span><span class="o">::</span><span class="no">Feed</span><span class="nf">.fetch_and_parse</span><span class="p">(</span><span class="s2">&quot;http://www.earthpublisher.com/georss.php&quot;</span><span class="p">)</span><span class="nf">.entries.each</span> <span class="k">do</span> <span class="o">|</span><span class="n">e</span><span class="o">|</span>
+          <span class="nb">p</span> <span class="s2">&quot;lat: </span><span class="si">#{</span><span class="n">e</span><span class="nf">.lat</span><span class="si">}</span><span class="s2">, long: </span><span class="si">#{</span><span class="n">e</span><span class="nf">.long</span><span class="si">}</span><span class="s2">&quot;</span>
+        <span class="k">end</span>
+        </td></tr></tbody></table></pre>
+        <h2>Testing</h2>
+
+        <p>Feedjira uses <a href="https://github.com/lostisland/faraday">faraday</a> to perform requests, so testing Feedjira is really
+        about <a href="https://github.com/lostisland/faraday#using-faraday-for-testing">stubbing out faraday requests</a>.</p>
+
+        <h2>Projects that use Feedjira</h2>
+
+        <p>Feedjira is used in some awesome projects around the web - from RSS readers to
+        add-ons and everything in between. Here are some of them:</p>
+
+        <ul>
+        <li><p><a href="https://feedbin.com/">Feedbin</a>: Feedbin bills itself as a fast, simple RSS reader that delivers a
+        great reading experience. It&rsquo;s a paid RSS reader that integrates with mobile
+        apps and it even has a fully featured API!</p></li>
+        <li><p><a href="https://github.com/swanson/stringer">Stringer</a>: Stringer is a self-hosted, anti-social RSS reader. It&rsquo;s an
+        open-source project that&rsquo;s easy to deploy to any host, there&rsquo;s even a
+        one-click button to deploy on Heroku.</p></li>
+        <li><p><a href="https://apps.shopify.com/blogfeeder">BlogFeeder</a>: BlogFeeder is a paid Shopify App that makes it easy for you to
+        import any external blog into your Shopify store. It helps improve your
+        store&rsquo;s SEO and keeps your blogs in sync, plus a lot more.</p></li>
+        <li><p><a href="https://github.com/amatriain/feedbunch">Feedbunch</a>: Feedbunch is an open source feed reader built to fill the hole
+        left by Google Reader. It aims to support all features of Google Reader and
+        actually improve on others.</p></li>
+        <li><p><a href="http://theoldreader.com/">The Old Reader</a>: The Old Reader advertises as the ultimate social RSS
+        reader. It&rsquo;s free to start and also has a paid premium version. There&rsquo;s an API
+        and it integrates with many different mobile apps.</p></li>
+        <li><p><a href="https://solveforall.com/">Solve for All</a>: Solve for All combines search engine and feed parsing
+        while protecting your privacy. It&rsquo;s even extendable by the community!</p></li>
+        </ul>
+
+        <p>Note: to get your project on this list, simply <a href="mailto:feedjira@gmail.com">send an email</a>
+        with your project&rsquo;s details.</p>
+        </section>
+        </div>
+        <footer>
+        <div class='column'>
+        <ul>
+        <li><a href="/">Home</a></li>
+        <li><a href="/blog/">Blog</a></li>
+        <li><a href="/blog/feed.xml">Feed</a></li>
+        <li><a target="_blank" href="https://github.com/feedjira/feedjira">Source</a></li>
+        <li><a target="_blank" href="https://twitter.com/feedjira">@feedjira</a></li>
+        </ul>
+        <p>Maintained by <a href="http://jonallured.com">Jon Allured</a>, Created by <a href="http://www.pauldix.net">Paul Dix</a>, Site design by <a href="http://danielariza.com">Daniel Ariza</a></p>
+        </div>
+        </footer>
+        <script type="text/javascript">
+          var _gaq = _gaq || [];
+          _gaq.push(["_setAccount", "UA-3137727-7"]);
+          _gaq.push(["_trackPageview"]);
+          (function() {
+            var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+            ga.src = ('https:' == document.location.protocol ? '//ssl' : '//www') + '.google-analytics.com/ga.js';
+            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+          })();
+        </script>
+        </body>
+        </html>
+    http_version: 
+  recorded_at: Mon, 31 Oct 2016 02:29:13 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/success.yml
+++ b/fixtures/vcr_cassettes/success.yml
@@ -1,0 +1,281 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://feedjira.com/blog/feed.xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Mon, 31 Oct 2016 02:29:13 GMT
+      server:
+      - Apache/2.4.18 (Ubuntu)
+      last-modified:
+      - Fri, 07 Oct 2016 14:37:00 GMT
+      etag:
+      - '"393e-53e4757c9db00-gzip"'
+      accept-ranges:
+      - bytes
+      vary:
+      - Accept-Encoding
+      content-length:
+      - '5051'
+      connection:
+      - close
+      content-type:
+      - application/xml
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>Feedjira Blog</title>
+          <subtitle>A Blog for Feedjira</subtitle>
+          <id>http://feedjira.com/blog</id>
+          <link href="http://feedjira.com/blog"/>
+          <link href="http://feedjira.com/blog/feed.xml" rel="self"/>
+          <updated>2015-06-05T00:00:00Z</updated>
+          <author>
+            <name>Jon Allured</name>
+          </author>
+          <entry>
+            <title>Feedjira Two-Point-Oh</title>
+            <link rel="alternate" href="http://feedjira.com/blog/2015/06/05/feedjira-two-point-oh.html"/>
+            <id>http://feedjira.com/blog/2015/06/05/feedjira-two-point-oh.html</id>
+            <published>2015-06-05T00:00:00Z</published>
+            <updated>2015-04-17T16:16:07-05:00</updated>
+            <author>
+              <name>Jon Allured</name>
+            </author>
+            <content type="html">&lt;p&gt;About a year ago, I took Feedjira to &lt;a href="http://feedjira.com/blog/2014/03/17/feedjira-goes-one-point-oh.html"&gt;version 1.0&lt;/a&gt; and today I&amp;rsquo;m releasing
+        version 2.0. Not much has changed actually - the biggest difference is that
+        &lt;code&gt;curb&lt;/code&gt; has been replaced with &lt;code&gt;faraday&lt;/code&gt;. For many users, upgrading to version
+        2.0 won&amp;rsquo;t require anything more than a &lt;code&gt;bundle update feedjira&lt;/code&gt;.&lt;/p&gt;
+
+        &lt;p&gt;The other big change is that the &lt;code&gt;Feedjira#update&lt;/code&gt; method was removed. It was
+        unreliable and mostly just caused issues. To read more about why this was
+        removed, check out &lt;a href="https://github.com/feedjira/feedjira/issues/218#issuecomment-40282091"&gt;this comment&lt;/a&gt; on a GitHub issue that was opened
+        about it not working as expected.&lt;/p&gt;
+
+        &lt;p&gt;I&amp;rsquo;ve also updated the site to reflect the changes in this version. I took the
+        opportunity to greatly simply things and got just about all the documentation to
+        fit on one page.&lt;/p&gt;
+
+        &lt;p&gt;I hope you like version 2.0 - feel free to hit me up &lt;a href="https://twitter.com/feedjira"&gt;on Twitter&lt;/a&gt; or if
+        you have any trouble, open a &lt;a href="https://github.com/feedjira/feedjira/issues"&gt;GitHub issue&lt;/a&gt; and I&amp;rsquo;ll give you a hand.&lt;/p&gt;
+
+        &lt;p&gt;Finally, thanks to those that gave me feedback on either my thoughts on version
+        2.0 or the release candidate - I really appreciate it!&lt;/p&gt;
+        </content>
+          </entry>
+          <entry>
+            <title>Thoughts on Version Two-Point-Oh</title>
+            <link rel="alternate" href="http://feedjira.com/blog/2014/04/14/thoughts-on-version-two-point-oh.html"/>
+            <id>http://feedjira.com/blog/2014/04/14/thoughts-on-version-two-point-oh.html</id>
+            <published>2014-04-14T00:00:00Z</published>
+            <updated>2014-09-05T12:15:28-05:00</updated>
+            <author>
+              <name>Jon Allured</name>
+            </author>
+            <content type="html">&lt;p&gt;TLDR: development of version 2.0 is being done on the &lt;a href="https://github.com/feedjira/feedjira/tree/two-point-oh"&gt;two-point-oh branch&lt;/a&gt;
+        and a &lt;a href="https://github.com/feedjira/feedjira/issues/221"&gt;GitHub issue&lt;/a&gt; is open for you to give feedback on its direction.&lt;/p&gt;
+
+        &lt;p&gt;I&amp;rsquo;ve starting work on a rewrite for Feedjira and I wanted to try using a &lt;a href="https://github.com/feedjira/feedjira/issues/221"&gt;GitHub
+        issue&lt;/a&gt; to discuss what I&amp;rsquo;d like to see in the new version. I&amp;rsquo;m very
+        interested in what users think, so please chime in!!&lt;/p&gt;
+
+        &lt;p&gt;In no particular order, here are some design goals for the new version:&lt;/p&gt;
+
+        &lt;h2&gt;Change HTTP Library&lt;/h2&gt;
+
+        &lt;p&gt;This gem depends on &lt;a href="https://github.com/taf2/curb"&gt;curb&lt;/a&gt;, but I&amp;rsquo;d like to switch that to something that will
+        allow me to support JRuby. I did some experimenting and really liked working
+        with &lt;a href="https://github.com/lostisland/faraday"&gt;Faraday&lt;/a&gt;, so that&amp;rsquo;s what I&amp;rsquo;m using at the moment.&lt;/p&gt;
+
+        &lt;h2&gt;Forget Concurrency&lt;/h2&gt;
+
+        &lt;p&gt;Throwing an array of feed urls at Feedjira and watching it concurrently fetch
+        and parse them extremely quickly is cool in READMEs and demos, but I don&amp;rsquo;t think
+        it&amp;rsquo;s reality. I think what&amp;rsquo;s much more likely is a single url being passed and
+        concurrency being dealt with in the application, workers being the likely
+        approach.&lt;/p&gt;
+
+        &lt;h2&gt;More Objects&lt;/h2&gt;
+
+        &lt;p&gt;Feedjira has a dirty little secret and it&amp;rsquo;s the &lt;code&gt;Feedjira::Feed&lt;/code&gt; class. If you
+        open that sucker up, you&amp;rsquo;ll see 19 class methods and 0 instance methods. These
+        class methods do everything from fetching and parsing to setting up curb and
+        unzipping raw xml. Not only is &lt;a href="http://en.wikipedia.org/wiki/Single_responsibility_principle"&gt;SRP&lt;/a&gt; off in the corner crying, its a mess to
+        test. I&amp;rsquo;d like to break this down into smaller objects that get instantiated and
+        passed around in normal OO fashion.&lt;/p&gt;
+
+        &lt;h2&gt;Fewer Parsers&lt;/h2&gt;
+
+        &lt;p&gt;One of the things I like best about Feedjira is the ability for a user to define
+        their own custom parsers and I think its under-used. What I&amp;rsquo;d like to see is
+        Feedjira ship with a parser for Atom and a parser for RSS - the others are
+        really just custom parsers.&lt;/p&gt;
+
+        &lt;h2&gt;Custom Parser Project&lt;/h2&gt;
+
+        &lt;p&gt;With version 1.2, I was able to spin off the benchmarks into &lt;a href="https://github.com/feedjira/feedjira-benchmarks"&gt;their own
+        project&lt;/a&gt; and I was very happy with how it turned out - I&amp;rsquo;d like to see a
+        similar thing happen with the custom parsers mentioned above. You should be able
+        to easily grab these parsers and throw them in your application. If you write a
+        particularly cool custom parser, then you could contribute it back and others
+        could benefit from it.&lt;/p&gt;
+
+        &lt;h2&gt;Raise Exceptions Instead of Callbacks&lt;/h2&gt;
+
+        &lt;p&gt;Feedjira almost never raises an exception and instead provides the ability to
+        register callbacks for success and failure situations, but this has proven
+        brittle and painful. With the new version, I want to see sensible exceptions
+        raised when something goes wrong and that pretty much removes the need for
+        callbacks, so those will be cut.&lt;/p&gt;
+
+        &lt;h2&gt;Feed Updating is Business Logic&lt;/h2&gt;
+
+        &lt;p&gt;The updating functionality of Feedjira leaves a lot to be desired - its
+        inconsistent and there are lots of edges. I tend to steer users away and
+        encourage them to write this kind of code in their application instead. See
+        &lt;a href="https://github.com/feedjira/feedjira/issues/218"&gt;this discussion&lt;/a&gt; for more, but needless to say, I&amp;rsquo;d like to see this entire
+        feature set removed.&lt;/p&gt;
+
+        &lt;h2&gt;Configuration&lt;/h2&gt;
+
+        &lt;p&gt;I want configuration for Feedjira done in a proper config block like most gems.
+        If you want to change the default parsers, that should be a config option. If
+        you want to set the user agent, that should be a configuration option.&lt;/p&gt;
+
+        &lt;h2&gt;Feedback Appreciated&lt;/h2&gt;
+
+        &lt;p&gt;Do you have any other ideas to make Feedjira better? Please check out the
+        &lt;a href="https://github.com/feedjira/feedjira/issues/221"&gt;GitHub issue&lt;/a&gt; and share what you&amp;rsquo;re thinking. I&amp;rsquo;m open to any feedback, so
+        if I just threw your favorite feature on the chopping block, please tell me!&lt;/p&gt;
+        </content>
+          </entry>
+          <entry>
+            <title>A Separate Project For Benchmarks</title>
+            <link rel="alternate" href="http://feedjira.com/blog/2014/04/11/a-separate-project-for-benchmarks.html"/>
+            <id>http://feedjira.com/blog/2014/04/11/a-separate-project-for-benchmarks.html</id>
+            <published>2014-04-11T00:00:00Z</published>
+            <updated>2014-09-05T12:15:28-05:00</updated>
+            <author>
+              <name>Jon Allured</name>
+            </author>
+            <content type="html">&lt;p&gt;With the release of version 1.2.0, the benchmarks for Feedjira have been moved
+        to a separate project: &lt;a href="https://github.com/feedjira/feedjira-benchmarks"&gt;https://github.com/feedjira/feedjira-benchmarks&lt;/a&gt;.&lt;/p&gt;
+
+        &lt;p&gt;What&amp;rsquo;s nice about this is that it keeps things much more organized and allowed
+        me to add a pretty neat new benchmark - more on that in a moment. I also rewrote
+        the &lt;a href="/benchmarks.html"&gt;Benchmarks page&lt;/a&gt; on this site so please check that out.&lt;/p&gt;
+
+        &lt;p&gt;One benchmark that I didn&amp;rsquo;t pull over to the new project is the fetching one. I
+        left it out because it relied on the consistency of your network connection and
+        that didn&amp;rsquo;t feel like it was scientific enough.&lt;/p&gt;
+
+        &lt;p&gt;In its place I&amp;rsquo;ve added a benchmark for parsing speed that&amp;rsquo;s run against each
+        version of the gem. Its pretty cool - when you clone down the
+        feedjira-benchmarks project, you also clone down feedjira itself and then the
+        script moves to each version tag in the git repo, runs the benchmark and records
+        the results. It was pretty fun to write and works like a charm.&lt;/p&gt;
+
+        &lt;p&gt;For the charts, I ended up learning some &lt;a href="http://www.r-project.org/"&gt;R&lt;/a&gt; so that I could have a little
+        more control.&lt;/p&gt;
+
+        &lt;p&gt;Benchmarks are really only valuable if they can be reproduced by others, so I&amp;rsquo;ve
+        written up instructions in the README for setting things up and running them. If
+        you&amp;rsquo;re interested, take a look and try running them yourself!&lt;/p&gt;
+
+        &lt;p&gt;I&amp;rsquo;ll continue to use the benchmarks to ensure Feedjira stays fast, so you wont
+        have to worry about your favorite Ruby feed library slowing down. If you have
+        any feedback for me on the benchmarks, feel free to hit me up on Twitter
+        (&lt;a href="https://twitter.com/feedjira"&gt;@feedjira&lt;/a&gt;) or &lt;a href="https://github.com/feedjira/feedjira-benchmarks/issues"&gt;open an issue&lt;/a&gt; on the project&amp;rsquo;s repo.&lt;/p&gt;
+        </content>
+          </entry>
+          <entry>
+            <title>Feedjira Goes One-Point-Oh</title>
+            <link rel="alternate" href="http://feedjira.com/blog/2014/03/17/feedjira-goes-one-point-oh.html"/>
+            <id>http://feedjira.com/blog/2014/03/17/feedjira-goes-one-point-oh.html</id>
+            <published>2014-03-17T00:00:00Z</published>
+            <updated>2014-09-05T12:15:28-05:00</updated>
+            <author>
+              <name>Jon Allured</name>
+            </author>
+            <content type="html">&lt;p&gt;Last fall, I asked &lt;a href="http://www.pauldix.net"&gt;Paul Dix&lt;/a&gt; if I could take over maintenance of his gem
+        Feedzirra. My request was totally out of the blue, so I was pretty pumped when
+        he got right back to me and said yes. He said that he didn&amp;rsquo;t have time to work
+        on it anymore and so I should feel free to do whatever I thought was best.&lt;/p&gt;
+
+        &lt;p&gt;Score!&lt;/p&gt;
+
+        &lt;p&gt;My first order of business was to go through the many open issues and pull
+        requests on GitHub. When I started there were over 60, a number that I&amp;rsquo;ve gotten
+        down to just a few. I thought it was important to ensure that users saw me treat
+        their issue as important and even if it was very old (which many were), I asked
+        if there was anything I could do to help.&lt;/p&gt;
+
+        &lt;p&gt;I was pleasantly surprised by the nice way many people responded and we got to
+        work addressing their questions and issues.&lt;/p&gt;
+
+        &lt;p&gt;As I was working through issues and pull requests, I kept &lt;a href="http://semver.org"&gt;SemVer&lt;/a&gt; in mind -
+        bug fixes in patch releases and backward-compatible changes in minor releases.
+        But I also realized that it was past time for this project to be at version 1.0.
+        In the SemVer FAQ, they talk about when to release version 1.0 and Feedzirra fit
+        the bill: it was being used in production, there was a stable API and I was
+        taking backwards compatibilty seriously.&lt;/p&gt;
+
+        &lt;p&gt;So I treated it as a project at 1.0 and I did my best to release versions that
+        were backward compatible and added deprecations for what I wanted to do in 1.0.
+        I saw things that I wanted to completely rewrite, but I resisted the urge to
+        burn it all down and start again.&lt;/p&gt;
+
+        &lt;p&gt;When I was close to being caught up on the backlog of issues and pull requests,
+        I started thinking about releasing version 1.0, and I knew I wanted to create a
+        website for the project. I worked with &lt;a href="http://danielariza.com"&gt;Daniel Ariza&lt;/a&gt; to make it happen. I
+        ripped apart the README and rewrote just about all the sections.&lt;/p&gt;
+
+        &lt;p&gt;There was an open issue on the project about renaming the Gem and I knew that
+        launching the website and releasing 1.0 would be the perfect opportunity, so I
+        went for it. There was a suggestion to change the name to Feedzilla, but since
+        that is already a thing, I went with Feedjira. I bought the domain and setup an
+        organization by that name on GitHub.&lt;/p&gt;
+
+        &lt;p&gt;With those things in place, I needed to actually update the code for these
+        changes. I wanted to make this transition as easy as possible and devised a
+        simple way to use &lt;a href="/versions.html"&gt;three versions&lt;/a&gt; to make the jump to 1.0.&lt;/p&gt;
+
+        &lt;p&gt;For most users, upgrading to 1.0 should be a breeze, but I have an &lt;a href="/upgrading.html"&gt;upgrade
+        page&lt;/a&gt; to help with a couple details. If you have any trouble upgrading,
+        please let me know by &lt;a href="https://github.com/feedjira/feedjira/issues"&gt;opening an issue&lt;/a&gt;.&lt;/p&gt;
+
+        &lt;p&gt;There are still lots of things I&amp;rsquo;d like to do with this Gem. I mentioned seeing
+        things that I wanted to completely rewrite, so that&amp;rsquo;ll be something that I work
+        on for a 2.0 release, but that&amp;rsquo;s a ways off. I&amp;rsquo;d like to officially support
+        JRuby. Many people use Feedjira with Rails, so a separate project that helps
+        those users get up and running quickly seems to have value.&lt;/p&gt;
+
+        &lt;p&gt;The list goes on.&lt;/p&gt;
+
+        &lt;p&gt;I do have a request before I finish this thing: I&amp;rsquo;d like to hear from users that
+        have apps in production using Feedjira. If you&amp;rsquo;re using Feedjira for a
+        commercial app, please &lt;a href="feedjira@gmail.com"&gt;email me&lt;/a&gt;!&lt;/p&gt;
+
+        &lt;p&gt;Thanks to everyone who has helped me accomplish this, but especially &lt;a href="http://www.pauldix.net"&gt;Paul
+        Dix&lt;/a&gt; for creating such a fun project to work on, &lt;a href="http://danielariza.com"&gt;Daniel Ariza&lt;/a&gt; for a
+        badass website design and the many people who opened issues or sent pull
+        requests. Open source is fun to work on because of people like you!! &amp;lt;3 &amp;lt;3 &amp;lt;3&lt;/p&gt;
+        </content>
+          </entry>
+        </feed>
+    http_version: 
+  recorded_at: Mon, 31 Oct 2016 02:29:13 GMT
+recorded_with: VCR 3.0.3

--- a/spec/feedjira/feed_spec.rb
+++ b/spec/feedjira/feed_spec.rb
@@ -13,28 +13,34 @@ end
 describe Feedjira::Feed do
   describe '.fetch_and_parse' do
     it 'raises an error when the fetch fails' do
-      url = 'http://www.example.com/feed.xml'
-      expect {
-        Feedjira::Feed.fetch_and_parse url
-      }.to raise_error Feedjira::FetchFailure
+      VCR.use_cassette('fetch_failure') do
+        url = 'http://www.example.com/feed.xml'
+        expect {
+          Feedjira::Feed.fetch_and_parse url
+        }.to raise_error Feedjira::FetchFailure
+      end
     end
 
     it 'raises an error when no parser can be found' do
-      url = 'http://feedjira.com'
-      expect {
-        Feedjira::Feed.fetch_and_parse url
-      }.to raise_error Feedjira::NoParserAvailable
+      VCR.use_cassette('parse_error') do
+        url = 'http://feedjira.com'
+        expect {
+          Feedjira::Feed.fetch_and_parse url
+        }.to raise_error Feedjira::NoParserAvailable
+      end
     end
 
     it 'fetches and parses the feed' do
-      url = 'http://feedjira.com/blog/feed.xml'
-      feed = Feedjira::Feed.fetch_and_parse url
+      VCR.use_cassette('success') do
+        url = 'http://feedjira.com/blog/feed.xml'
+        feed = Feedjira::Feed.fetch_and_parse url
 
-      expect(feed.class).to eq Feedjira::Parser::Atom
-      expect(feed.entries.count).to eq 4
-      expect(feed.feed_url).to eq url
-      expect(feed.etag).to eq '393e-53e4757c9db00-gzip'
-      expect(feed.last_modified).to eq 'Fri, 07 Oct 2016 14:37:00 GMT'
+        expect(feed.class).to eq Feedjira::Parser::Atom
+        expect(feed.entries.count).to eq 4
+        expect(feed.feed_url).to eq url
+        expect(feed.etag).to eq('393e-53e4757c9db00-gzip')
+        expect(feed.last_modified).to eq('Fri, 07 Oct 2016 14:37:00 GMT')
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,13 @@
 require File.expand_path(File.dirname(__FILE__) + '/../lib/feedjira')
 require 'sample_feeds'
+require 'vcr'
 
 SAXMachine.handler = ENV['HANDLER'].to_sym if ENV['HANDLER']
+
+VCR.configure do |config|
+  config.cassette_library_dir = 'fixtures/vcr_cassettes'
+  config.hook_into :faraday
+end
 
 RSpec.configure do |c|
   c.include SampleFeeds


### PR DESCRIPTION
there are three tests in feed_spec that require network to pass.

PR #297 fixes the immediate issue by making the test general enough to
pass when the response from the server changes somewhat.

PR #300 fixes the network issue, but uses specific stubs. I would say
this method is no better or worse than this one, however it does require
knowing that you are stubbing the request and manually keeping responses
up to date.

This method acts the most like actually hitting the network and will
work on an airplane.