### PR TITLE
Allow single quoted attributes in iTunes RSS feeds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: jruby-9
+    - rvm: rbx
   exclude:
     - rvm: jruby-9
       env: HANDLER=ox

--- a/lib/feedjira/parser/atom.rb
+++ b/lib/feedjira/parser/atom.rb
@@ -14,7 +14,7 @@ module Feedjira
       elements :entry, as: :entries, class: AtomEntry
 
       def self.able_to_parse?(xml)
-        %r{\<feed[^\>]+xmlns\s?=\s?[\"|\'](http://www\.w3\.org/2005/Atom|http://purl\.org/atom/ns\#)[\"|\'][^\>]*\>} =~ xml # rubocop:disable Metrics/LineLength
+        %r{\<feed[^\>]+xmlns\s?=\s?[\"\'](http://www\.w3\.org/2005/Atom|http://purl\.org/atom/ns\#)[\"\'][^\>]*\>} =~ xml # rubocop:disable Metrics/LineLength
       end
 
       def url

--- a/lib/feedjira/parser/google_docs_atom.rb
+++ b/lib/feedjira/parser/google_docs_atom.rb
@@ -17,7 +17,7 @@ module Feedjira
       end
 
       def self.able_to_parse?(xml) #:nodoc:
-        %r{<id>https?://docs.google.com/.*\</id\>} =~ xml
+        %r{<id>https?://docs\.google\.com/.*\</id\>} =~ xml
       end
 
       def feed_url

--- a/lib/feedjira/parser/itunes_rss.rb
+++ b/lib/feedjira/parser/itunes_rss.rb
@@ -38,7 +38,7 @@ module Feedjira
       elements :item, as: :entries, class: ITunesRSSItem
 
       def self.able_to_parse?(xml)
-        %r{xmlns:itunes\s?=\s?\"http://www\.itunes\.com/dtds/podcast-1\.0\.dtd\"}i =~ xml # rubocop:disable Metrics/LineLength
+        %r{xmlns:itunes\s?=\s?[\"\']http://www\.itunes\.com/dtds/podcast-1\.0\.dtd[\"\']}i =~ xml # rubocop:disable Metrics/LineLength
       end
     end
   end

--- a/lib/feedjira/parser/itunes_rss.rb
+++ b/lib/feedjira/parser/itunes_rss.rb
@@ -38,7 +38,7 @@ module Feedjira
       elements :item, as: :entries, class: ITunesRSSItem
 
       def self.able_to_parse?(xml)
-        %r{xmlns:itunes\s?=\s?\"http://www.itunes.com/dtds/podcast-1.0.dtd\"}i =~ xml # rubocop:disable Metrics/LineLength
+        %r{xmlns:itunes\s?=\s?\"http://www\.itunes\.com/dtds/podcast-1\.0\.dtd\"}i =~ xml # rubocop:disable Metrics/LineLength
       end
     end
   end

--- a/spec/feedjira/feed_spec.rb
+++ b/spec/feedjira/feed_spec.rb
@@ -33,8 +33,8 @@ describe Feedjira::Feed do
       expect(feed.class).to eq Feedjira::Parser::Atom
       expect(feed.entries.count).to eq 4
       expect(feed.feed_url).to eq url
-      expect(feed.etag).to eq 'a21c2-393e-518529acc04c0'
-      expect(feed.last_modified).to eq 'Fri, 12 Jun 2015 14:05:47 GMT'
+      expect(feed.etag).to eq '393e-53e4757c9db00-gzip'
+      expect(feed.last_modified).to eq 'Fri, 07 Oct 2016 14:37:00 GMT'
     end
   end
 

--- a/spec/feedjira/parser/itunes_rss_spec.rb
+++ b/spec/feedjira/parser/itunes_rss_spec.rb
@@ -10,6 +10,10 @@ module Feedjira::Parser
       expect(ITunesRSS).to be_able_to_parse(sample_itunes_feed_with_spaces)
     end
 
+    it 'should return true for an itunes RSS feed with single-quoted attributes' do # rubocop:disable Metrics/LineLength
+      expect(ITunesRSS).to be_able_to_parse(sample_itunes_feed_with_single_quotes)  # rubocop:disable Metrics/LineLength
+    end
+
     it 'should return fase for an atom feed' do
       expect(ITunesRSS).to_not be_able_to_parse(sample_atom_feed)
     end

--- a/spec/sample_feeds.rb
+++ b/spec/sample_feeds.rb
@@ -8,6 +8,7 @@ module SampleFeeds
     sample_atom_feed_line_breaks: 'AtomFeedWithSpacesAroundEquals.xml',
     sample_atom_entry_content: 'AmazonWebServicesBlogFirstEntryContent.xml',
     sample_itunes_feed: 'itunes.xml',
+    sample_itunes_feed_with_single_quotes: 'ITunesWithSingleQuotedAttributes.xml',
     sample_itunes_feed_with_spaces: 'ITunesWithSpacesInAttributes.xml',
     sample_rdf_feed: 'HREFConsideredHarmful.xml',
     sample_rdf_entry_content: 'HREFConsideredHarmfulFirstEntry.xml',

--- a/spec/sample_feeds/ITunesWithSingleQuotedAttributes.xml
+++ b/spec/sample_feeds/ITunesWithSingleQuotedAttributes.xml
@@ -1,0 +1,67 @@
+
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:itunes='http://www.itunes.com/dtds/podcast-1.0.dtd' version='2.0'>
+
+<channel>
+<title>All About Everything</title>
+<link>http://www.example.com/podcasts/everything/index.html</link>
+<language>en-us</language>
+<copyright>&#x2117; &amp; &#xA9; 2005 John Doe &amp; Family</copyright>
+<itunes:subtitle>A show about everything</itunes:subtitle>
+<itunes:new-feed-url>http://example.com/new.xml</itunes:new-feed-url>
+<itunes:author>John Doe</itunes:author>
+<itunes:summary>All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our Podcast in the iTunes Music Store</itunes:summary>
+<description>All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our Podcast in the iTunes Music Store</description>
+<itunes:owner>
+<itunes:name>John Doe</itunes:name>
+<itunes:email>john.doe@example.com</itunes:email>
+</itunes:owner>
+<itunes:image href='http://example.com/podcasts/everything/AllAboutEverything.jpg' />
+<itunes:category text='Technology'>
+<itunes:category text='Gadgets'/>
+<itunes:category text='TV &amp; Film'/>
+
+<item>
+<title>Shake Shake Shake Your Spices</title>
+<itunes:author>John Doe</itunes:author>
+<itunes:subtitle>A short primer on table spices</itunes:subtitle>
+<itunes:summary>This week we talk about salt and pepper shakers, comparing and contrasting pour rates, construction materials, and overall aesthetics. Come and join the party!</itunes:summary>
+<enclosure url='http://example.com/podcasts/everything/AllAboutEverythingEpisode3.m4a' length='8727310' type='audio/x-m4a' />
+<guid>http://example.com/podcasts/archive/aae20050615.m4a</guid>
+<pubDate>Wed, 15 Jun 2005 19:00:00 GMT</pubDate>
+<itunes:duration>7:04</itunes:duration>
+<itunes:keywords>salt, pepper, shaker, exciting</itunes:keywords>
+<itunes:image href='http://example.com/podcasts/everything/AllAboutEverything.jpg' />
+<itunes:order>12</itunes:order>
+<itunes:isClosedCaptioned>yes</itunes:isClosedCaptioned>
+<content:encoded>&lt;p&gt;&lt;strong&gt;TOPIC&lt;/strong&gt;: Gooseneck Options&lt;/p&gt;</content:encoded>
+</item>
+
+<item>
+<title>Socket Wrench Shootout</title>
+<itunes:author>Jane Doe</itunes:author>
+<itunes:subtitle>Comparing socket wrenches is fun!</itunes:subtitle>
+<itunes:summary>This week we talk about metric vs. old english socket wrenches. Which one is better? Do you really need both? Get all of your answers here.</itunes:summary>
+<enclosure url='http://example.com/podcasts/everything/AllAboutEverythingEpisode2.mp3' length='5650889' type='audio/mpeg' />
+<guid>http://example.com/podcasts/archive/aae20050608.mp3</guid>
+<pubDate>Wed, 8 Jun 2005 19:00:00 GMT</pubDate>
+<itunes:duration>4:34</itunes:duration>
+<itunes:keywords>metric, socket, wrenches, tool</itunes:keywords>
+<itunes:image href='http://example.com/podcasts/everything/AllAboutEverything.jpg' />
+</item>
+
+<item>
+<title>Red, Whine, &amp; Blue</title>
+<itunes:author>Various</itunes:author>
+<itunes:subtitle>Red + Blue != Purple</itunes:subtitle>
+<itunes:summary>This week we talk about surviving in a Red state if you are a Blue person. Or vice versa.</itunes:summary>
+<enclosure url='http://example.com/podcasts/everything/AllAboutEverythingEpisode1.mp3' length='4989537' type='audio/mpeg' />
+<guid>http://example.com/podcasts/archive/aae20050601.mp3</guid>
+<pubDate>Wed, 1 Jun 2005 19:00:00 GMT</pubDate>
+<itunes:duration>3:59</itunes:duration>
+<itunes:keywords>politics, red, blue, state</itunes:keywords>
+<itunes:image href='http://example.com/podcasts/everything/AllAboutEverything.jpg' />
+</item>
+
+</channel>
+</rss>


### PR DESCRIPTION
I came across an iTunes RSS feed that was perfectly valid but `Feedjira::Parser::ITunesRSS.able_to_parse?` was returning `false` because the feed used single-quotes instead of double-quotes around attributes. Specifically, around:

```xml
<rss version='2.0' xmlns:itunes='http://www.itunes.com/dtds/podcast-1.0.dtd'> 
```

This pull request updates the regular expression to allow either single or double quotes, as well as cleaning up a few other related issues.