### PR TITLE
Add a missing podcast attribute `itunes_complete` to ITunesRSS

### DIFF
--- a/lib/feedjira/parser/itunes_rss.rb
+++ b/lib/feedjira/parser/itunes_rss.rb
@@ -21,6 +21,7 @@ module Feedjira
       element :"itunes:block", as: :itunes_block
       element :"itunes:image", value: :href, as: :itunes_image
       element :"itunes:explicit", as: :itunes_explicit
+      element :"itunes:complete", as: :itunes_complete
       element :"itunes:keywords", as: :itunes_keywords
 
       # New URL for the podcast feed

--- a/spec/feedjira/parser/itunes_rss_spec.rb
+++ b/spec/feedjira/parser/itunes_rss_spec.rb
@@ -56,6 +56,10 @@ module Feedjira::Parser
       expect(@feed.itunes_summary).to eq summary
     end
 
+    it 'should parse the complete tag' do
+      expect(@feed.itunes_complete).to eq 'yes'
+    end
+
     it 'should parse entries' do
       expect(@feed.entries.size).to eq 3
     end

--- a/spec/sample_feeds/itunes.xml
+++ b/spec/sample_feeds/itunes.xml
@@ -12,6 +12,7 @@
 <itunes:author>John Doe</itunes:author>
 <itunes:summary>All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our Podcast in the iTunes Music Store</itunes:summary>
 <description>All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our Podcast in the iTunes Music Store</description>
+<itunes:complete>yes</itunes:complete>
 <itunes:owner>
 <itunes:name>John Doe</itunes:name>
 <itunes:email>john.doe@example.com</itunes:email>


### PR DESCRIPTION
It is documented here: https://help.apple.com/itc/podcasts_connect/#/itcb54353390