### PR TITLE
disable danger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_install:
 
 script:
   - bundle exec rake
-  - bundle exec danger
 
 notifications:
   email: false


### PR DESCRIPTION
Disable danger until we figure out how to resolve builds that fail due to danger breaking.
Tracked in issue #330 merge before https://github.com/feedjira/feedjira/pull/277

@krasnoukhov look good?

I think we should leave the Dangerfile around while we see if we can get actionable messages out of danger.