### PR TITLE
Add ttl and last_built elements to RSS and ITunesRSS parsers

### DIFF
--- a/lib/feedjira/parser/itunes_rss.rb
+++ b/lib/feedjira/parser/itunes_rss.rb
@@ -1,7 +1,10 @@
 module Feedjira
   module Parser
     # iTunes is RSS 2.0 + some apple extensions
-    # Source: http://www.apple.com/itunes/whatson/podcasts/specs.html
+    # Sources:
+    #   * https://cyber.harvard.edu/rss/rss.html
+    #   * http://lists.apple.com/archives/syndication-dev/2005/Nov/msg00002.html
+    #   * https://help.apple.com/itc/podcasts_connect/
     class ITunesRSS
       include SAXMachine
       include FeedUtilities

--- a/lib/feedjira/parser/itunes_rss.rb
+++ b/lib/feedjira/parser/itunes_rss.rb
@@ -15,6 +15,8 @@ module Feedjira
       element :managingEditor
       element :title
       element :link, as: :url
+      element :lastBuildDate, as: :last_built
+      element :ttl
 
       # If author is not present use managingEditor on the channel
       element :"itunes:author", as: :itunes_author

--- a/lib/feedjira/parser/rss.rb
+++ b/lib/feedjira/parser/rss.rb
@@ -9,6 +9,8 @@ module Feedjira
       element :description
       element :link, as: :url
       element :language
+      element :lastBuildDate, as: :last_built
+      element :ttl
       elements :item, as: :entries, class: RSSEntry
       elements :"atom:link", as: :hubs, value: :href, with: { rel: 'hub' }
 

--- a/lib/feedjira/parser/rss.rb
+++ b/lib/feedjira/parser/rss.rb
@@ -1,6 +1,7 @@
 module Feedjira
   module Parser
     # Parser for dealing with RSS feeds.
+    # Source: https://cyber.harvard.edu/rss/rss.html
     class RSS
       include SAXMachine
       include FeedUtilities

--- a/lib/feedjira/parser/rss_feed_burner.rb
+++ b/lib/feedjira/parser/rss_feed_burner.rb
@@ -7,6 +7,7 @@ module Feedjira
       element :title
       element :description
       element :link, as: :url
+      element :lastBuildDate, as: :last_built
       elements :"atom10:link", as: :hubs, value: :href, with: { rel: 'hub' }
       elements :item, as: :entries, class: RSSFeedBurnerEntry
 

--- a/spec/feedjira/parser/itunes_rss_spec.rb
+++ b/spec/feedjira/parser/itunes_rss_spec.rb
@@ -28,6 +28,14 @@ module Feedjira::Parser
       @feed = ITunesRSS.parse(sample_itunes_feed)
     end
 
+    it 'should parse the ttl' do
+      expect(@feed.ttl).to eq '60'
+    end
+
+    it 'should parse the last build date' do
+      expect(@feed.last_built).to eq 'Sat, 07 Sep 2002 09:42:31 GMT'
+    end
+
     it 'should parse the subtitle' do
       expect(@feed.itunes_subtitle).to eq 'A show about everything'
     end

--- a/spec/feedjira/parser/rss_feed_burner_spec.rb
+++ b/spec/feedjira/parser/rss_feed_burner_spec.rb
@@ -41,6 +41,10 @@ module Feedjira::Parser
       expect(@feed.url).to eq 'http://techcrunch.com'
     end
 
+    it 'should parse the last build date' do
+      expect(@feed.last_built).to eq 'Wed, 02 Nov 2011 17:29:59 +0000'
+    end
+
     it 'should parse the hub urls' do
       expect(@feed.hubs.count).to eq 2
       expect(@feed.hubs.first).to eq 'http://pubsubhubbub.appspot.com/'

--- a/spec/feedjira/parser/rss_spec.rb
+++ b/spec/feedjira/parser/rss_spec.rb
@@ -37,6 +37,14 @@ describe Feedjira::Parser::RSS do
       expect(@feed.url).to eq 'http://tenderlovemaking.com'
     end
 
+    it 'should parse the ttl' do
+      expect(@feed.ttl).to eq '60'
+    end
+
+    it 'should parse the last build date' do
+      expect(@feed.last_built).to eq 'Sat, 07 Sep 2002 09:42:31 GMT'
+    end
+
     it 'should parse the hub urls' do
       expect(@feed.hubs.count).to eq 1
       expect(@feed.hubs.first).to eq 'http://pubsubhubbub.appspot.com/'

--- a/spec/sample_feeds/TenderLovemaking.xml
+++ b/spec/sample_feeds/TenderLovemaking.xml
@@ -16,6 +16,8 @@
 	<pubDate>Mon, 29 Dec 2008 07:51:19 +0000</pubDate>
 	<generator>http://wordpress.org/?v=2.7</generator>
 	<language>en</language>
+	<lastBuildDate>Sat, 07 Sep 2002 09:42:31 GMT</lastBuildDate>
+	<ttl>60</ttl>
 	<sy:updatePeriod>hourly</sy:updatePeriod>
 	<sy:updateFrequency>1</sy:updateFrequency>
     <atom:link rel="hub" href="http://pubsubhubbub.appspot.com/"/>

--- a/spec/sample_feeds/itunes.xml
+++ b/spec/sample_feeds/itunes.xml
@@ -7,6 +7,8 @@
 <link>http://www.example.com/podcasts/everything/index.html</link>
 <language>en-us</language>
 <copyright>&#x2117; &amp; &#xA9; 2005 John Doe &amp; Family</copyright>
+<lastBuildDate>Sat, 07 Sep 2002 09:42:31 GMT</lastBuildDate>
+<ttl>60</ttl>
 <itunes:subtitle>A show about everything</itunes:subtitle>
 <itunes:new-feed-url>http://example.com/new.xml</itunes:new-feed-url>
 <itunes:author>John Doe</itunes:author>


### PR DESCRIPTION
These elements are part of the [RSS 2.0 specification](http://cyber.harvard.edu/rss/rss.html).

According to the [RSS Advisory Board](http://www.rssboard.org/rss-profile#element-channel-ttl):

> Twenty-one percent of surveyed feeds included a `ttl` element.

That survey was taken in 2007. The practice of including a `ttl` element has even wider adoption today, especially among podcast feeds.

It is also mentioned on the original [`syndication-dev` mailing list](http://lists.apple.com/archives/syndication-dev/2005/Nov/msg00002.html) in 2005:

> The ttl tag stands for "time-to-live". It is an optional integer value that controls how many minutes iTunes will wait between checking for changes in a podcast. If no time-to-live is set on the podcast, the updater job assumes a time-to-live of 24 hours.

Finally, here is [a post from Dave Winer on the topic](http://scripting.com/2006/09/07.html#theRssTtlElementAndP2pNetworks) in 2006:

> Here’s how ttl was intended to work. Suppose you have a copy of Gnutella running on your machine, and I have one running on my machine. My machine wants a copy of a certain feed, so it asks your machine if it has it. Your copy of Gnutella looks in its cache, finds a copy of the feed, takes the lastBuildDate, adds its ttl value. If the resulting time is greater than the current time, it says yes, I can give you that, otherwise it says no. If your Gnutella strikes out, if everyone it asks says no, it reads the feed from the feed’s server.