### PR TITLE
Changed the direction of DateParsers

### DIFF
--- a/lib/feedjira/date_time_utilities.rb
+++ b/lib/feedjira/date_time_utilities.rb
@@ -3,9 +3,9 @@ module Feedjira
     # This is our date parsing heuristic.
     # Date Parsers are attempted in order.
     DATE_PARSERS = [
-      DateTime,
       DateTimePatternParser,
-      DateTimeLanguageParser
+      DateTimeLanguageParser,
+      DateTime
     ].freeze
 
     # Parse the given string starting with the most common parser (default ruby)


### PR DESCRIPTION
The ruby Default Parser sometimes does strange things. For example it parses `水, 31 8 2016 07:37:00 PDT'` to `2016-12-31 14:37:00.000000000 +0000`

So it's necessary to first check for "special pattern" and then use the default parser.