### PR TITLE
update changelog and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Feedjira Changelog
 
+## 2.1.0
+
+* Enhancements
+  * AtomYoutube is now a supported parser [#337][] (@jfiorato)
+  * Oga parsing is now supported [#331][] (@krasnoukhov)
+  * DateTime Handler now supports localized dates [#313][] (@PascalTurbo)
+  * RSS now supports language attribute [#344][] (@PascalTurbo)
+  * ITunesRSS added support for:
+    * `ttl` and `last_built` [#343][] (@sferik)
+    * `itunes_category` and `itunes_category_paths` [#329][] (@knu)
+    * `itunes_complete` [#328][] (@knu)
+    * single quoted attributes [#326][] (@sferik)
+    * Add image attribute [#349][] (@sferik)
+
 ## 2.0.0
 
 * General

--- a/lib/feedjira/version.rb
+++ b/lib/feedjira/version.rb
@@ -1,3 +1,3 @@
 module Feedjira
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.1.0'.freeze
 end


### PR DESCRIPTION
We have a healthy list of authors this release,

@jfiorato
@krasnoukhov
@PascalTurbo
@sferik
@knu

Thanks so much for your work improving Feedjira. Assuming the build comes back green I propose we call this 2.1.0 tomorrow. Any objections?