### PR TITLE
Detect Atom feeds with root namespace prefix

### DIFF
--- a/lib/feedjira/parser/atom.rb
+++ b/lib/feedjira/parser/atom.rb
@@ -14,7 +14,7 @@ module Feedjira
       elements :entry, as: :entries, class: AtomEntry
 
       def self.able_to_parse?(xml)
-        %r{\<feed[^\>]+xmlns\s?=\s?[\"\'](http://www\.w3\.org/2005/Atom|http://purl\.org/atom/ns\#)[\"\'][^\>]*\>} =~ xml # rubocop:disable Metrics/LineLength
+        %r{\<(?:\S*\:)?feed[^\>]+xmlns(?:\:\S*)?\s?=\s?[\"\'](http://www\.w3\.org/2005/Atom|http://purl\.org/atom/ns\#)[\"\'][^\>]*\>} =~ xml # rubocop:disable Metrics/LineLength
       end
 
       def url

--- a/spec/feedjira/parser/atom_spec.rb
+++ b/spec/feedjira/parser/atom_spec.rb
@@ -18,7 +18,7 @@ module Feedjira::Parser
       expect(Atom).to be_able_to_parse(sample_atom_feed_line_breaks)
     end
 
-    it 'should return true for an atom feed with a root element namespace prefix' do
+    it 'should return true for an atom feed with a root element namespace prefix' do # rubocop:disable Metrics/LineLength
       expect(Atom).to be_able_to_parse(sample_atom_feed_with_prefix)
     end
   end

--- a/spec/feedjira/parser/atom_spec.rb
+++ b/spec/feedjira/parser/atom_spec.rb
@@ -17,6 +17,10 @@ module Feedjira::Parser
     it 'should return true for an atom feed that has line breaks in between attributes in the <feed> node' do # rubocop:disable Metrics/LineLength
       expect(Atom).to be_able_to_parse(sample_atom_feed_line_breaks)
     end
+
+    it 'should return true for an atom feed with a root element namespace prefix' do
+      expect(Atom).to be_able_to_parse(sample_atom_feed_with_prefix)
+    end
   end
 
   describe 'parsing' do
@@ -85,6 +89,14 @@ module Feedjira::Parser
       feed = Atom.parse sample_duplicate_content_atom_feed
       content = Nokogiri::HTML(feed.entries[1].content)
       expect(content.css('img').length).to eq 11
+    end
+
+    it 'should parse a feed that is completely prefixed' do
+      Atom.preprocess_xml = true
+
+      feed = Atom.parse sample_atom_feed_with_prefix
+      content = Nokogiri::HTML(feed.entries[1].content)
+      expect(content.text).to match(/type publicatie:/i)
     end
   end
 

--- a/spec/sample_feeds.rb
+++ b/spec/sample_feeds.rb
@@ -25,7 +25,8 @@ module SampleFeeds
     sample_feed_burner_atom_xhtml_feed: 'FeedBurnerXHTML.xml',
     sample_duplicate_content_atom_feed: 'DuplicateContentAtomFeed.xml',
     sample_youtube_atom_feed: 'youtube_atom.xml',
-    sample_atom_xhtml_with_escpaed_html_in_pre_tag_feed: 'AtomEscapedHTMLInPreTag.xml'
+    sample_atom_xhtml_with_escpaed_html_in_pre_tag_feed: 'AtomEscapedHTMLInPreTag.xml',
+    sample_atom_feed_with_prefix: 'AtomWithPrefix.xml'
   }.freeze
 
   FEEDS.each do |method, filename|

--- a/spec/sample_feeds/AtomWithPrefix.xml
+++ b/spec/sample_feeds/AtomWithPrefix.xml
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<atom:feed xmlns:atom="http://www.w3.org/2005/Atom">
+   <atom:title>TenderNed NL : Laatste Publicaties</atom:title>
+   <atom:subtitle>Laatste Publicaties</atom:subtitle>
+   <atom:updated>2016-12-12T16:30:04.445+01:00</atom:updated>
+   <atom:id>https://www.tenderned.nl/tenderned-rss-web/rss/laatste-publicatie.rss</atom:id>
+   <atom:link href="https://www.tenderned.nl/tenderned-rss-web/rss/laatste-publicatie.rss" rel="self" />
+   <atom:entry>
+      <atom:title>Voorlichtingsteam voor verkeersveiligheid in Brabant, C2193147 - Provincie Noord-Brabant</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/6c8f852a06257d45862560a95729c1e1" />
+      <atom:updated>2016-12-12T16:30:04.445+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/6c8f852a06257d45862560a95729c1e1</atom:id>
+      <atom:published>2016-12-12T16:30:04.445+01:00</atom:published>
+      <atom:author>
+         <atom:name>Provincie Noord-Brabant</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 12-10-2016 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 79342200-5-Promotiediensten</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 12-10-2016 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 79342200-5-Promotiediensten</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Het leveren van kleine en middelgrote veegmachines - Stadswerk 072 N.V.</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/b180160e3ae7a068b753da6d078f8536" />
+      <atom:updated>2016-12-12T16:30:03.434+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/b180160e3ae7a068b753da6d078f8536</atom:id>
+      <atom:published>2016-12-12T16:30:03.434+01:00</atom:published>
+      <atom:author>
+         <atom:name>Stadswerk 072 N.V.</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Leveringen | Sluitingsdatum: 07-09-2016 | Plaats van uitvoering: Alkmaar en omgeving NL322, NEDERLAND NL | Procedure: Openbaar | CPV: 34921100-0-Straatveegmachines</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Leveringen | Sluitingsdatum: 07-09-2016 | Plaats van uitvoering: Alkmaar en omgeving NL322, NEDERLAND NL | Procedure: Openbaar | CPV: 34921100-0-Straatveegmachines</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Onderhoud Railinfrastructuur Uithoflijn - Provincie Utrecht</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/fd711692dfe0b6ec80c9b577f8c4b5d6" />
+      <atom:updated>2016-12-12T16:30:02.365+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/fd711692dfe0b6ec80c9b577f8c4b5d6</atom:id>
+      <atom:published>2016-12-12T16:30:02.365+01:00</atom:published>
+      <atom:author>
+         <atom:name>Provincie Utrecht</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Kennisgeving van aanvullende informatie, informatie over een onvolledige procedure of rectificatie | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 20-01-2017 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 50225000-8-Onderhoud van rails</atom:content>
+      <atom:summary>Type publicatie: Kennisgeving van aanvullende informatie, informatie over een onvolledige procedure of rectificatie | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 20-01-2017 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 50225000-8-Onderhoud van rails</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Vaste Dataverbindingen - Waterschap Rijn en IJssel</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/87f97cef63f92411d3cde7402a02df79" />
+      <atom:updated>2016-12-12T16:30:01.640+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/87f97cef63f92411d3cde7402a02df79</atom:id>
+      <atom:published>2016-12-12T16:30:01.640+01:00</atom:published>
+      <atom:author>
+         <atom:name>Waterschap Rijn en IJssel</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 16-03-2017 | Plaats van uitvoering: NEDERLAND NL, Achterhoek NL225 | Procedure: Niet-openbaar | CPV: 32400000-7-Netwerken</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 16-03-2017 | Plaats van uitvoering: NEDERLAND NL, Achterhoek NL225 | Procedure: Niet-openbaar | CPV: 32400000-7-Netwerken</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Reconstructie Rioolseweg en Kuijerstraat - Gemeente Etten-Leur</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/2f47f3e7e889eca72f31085435174511" />
+      <atom:updated>2016-12-12T16:29:13.387+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/2f47f3e7e889eca72f31085435174511</atom:id>
+      <atom:published>2016-12-12T16:29:13.387+01:00</atom:published>
+      <atom:author>
+         <atom:name>Gemeente Etten-Leur</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Kennisgeving van aanvullende informatie, informatie over een onvolledige procedure of rectificatie | Publicatiedatum: 12-12-2016 | Type opdracht: Werken | Sluitingsdatum: 19-12-2016 | Plaats van uitvoering: West-Noord-Brabant NL411, NEDERLAND NL | Procedure: Openbaar | CPV: 45233141-9-Wegenonderhoud</atom:content>
+      <atom:summary>Type publicatie: Kennisgeving van aanvullende informatie, informatie over een onvolledige procedure of rectificatie | Publicatiedatum: 12-12-2016 | Type opdracht: Werken | Sluitingsdatum: 19-12-2016 | Plaats van uitvoering: West-Noord-Brabant NL411, NEDERLAND NL | Procedure: Openbaar | CPV: 45233141-9-Wegenonderhoud</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Mobiliteit - full operational lease - Waterschap Hunze en Aa's</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/a9cd118ceb12db3755c7f788ca4ce796" />
+      <atom:updated>2016-12-12T16:15:04.437+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/a9cd118ceb12db3755c7f788ca4ce796</atom:id>
+      <atom:published>2016-12-12T16:15:04.437+01:00</atom:published>
+      <atom:author>
+         <atom:name>Waterschap Hunze en Aa's</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 18-10-2016 | Plaats van uitvoering: NOORD-NEDERLAND NL1 | Procedure: Openbaar | CPV: 34100000-8-Motorvoertuigen</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 18-10-2016 | Plaats van uitvoering: NOORD-NEDERLAND NL1 | Procedure: Openbaar | CPV: 34100000-8-Motorvoertuigen</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Aanbesteding tankpassen gemeente Meierijstad - Gemeente Sint-Oedenrode</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/6704ec0e7d30fe74336fa0b26af48d43" />
+      <atom:updated>2016-12-12T16:15:03.388+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/6704ec0e7d30fe74336fa0b26af48d43</atom:id>
+      <atom:published>2016-12-12T16:15:03.388+01:00</atom:published>
+      <atom:author>
+         <atom:name>Gemeente Sint-Oedenrode</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 14-11-2016 | Plaats van uitvoering: NEDERLAND NL, Noordoost-Noord-Brabant NL413 | Procedure: Openbaar | CPV: 09100000-0-Brandstoffen</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 14-11-2016 | Plaats van uitvoering: NEDERLAND NL, Noordoost-Noord-Brabant NL413 | Procedure: Openbaar | CPV: 09100000-0-Brandstoffen</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Onafhankelijke steekproefmetingen OV Concessies - Provincie Noord-Brabant</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/166902b79b518b5c4457c31650e2e2c3" />
+      <atom:updated>2016-12-12T16:15:01.483+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/166902b79b518b5c4457c31650e2e2c3</atom:id>
+      <atom:published>2016-12-12T16:15:01.483+01:00</atom:published>
+      <atom:author>
+         <atom:name>Provincie Noord-Brabant</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 20-10-2016 | Plaats van uitvoering: Noord-Brabant NL41, NEDERLAND NL | Procedure: Openbaar | CPV: 79310000-0-Uitvoeren van marktonderzoek</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 20-10-2016 | Plaats van uitvoering: Noord-Brabant NL41, NEDERLAND NL | Procedure: Openbaar | CPV: 79310000-0-Uitvoeren van marktonderzoek</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>AI 2017-0001 Perceel 3 verbouwing stadhuis - Gemeente Amsterdam, Ingenieursbureau</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/4be022ea506fda0d62be8cedac5de65d" />
+      <atom:updated>2016-12-12T16:00:02.617+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/4be022ea506fda0d62be8cedac5de65d</atom:id>
+      <atom:published>2016-12-12T16:00:02.617+01:00</atom:published>
+      <atom:author>
+         <atom:name>Gemeente Amsterdam, Ingenieursbureau</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Vooraankondiging | Publicatiedatum: 12-12-2016 | Type opdracht: Werken | Sluitingsdatum: 13-03-2017 | Plaats van uitvoering: Groot-Amsterdam NL326, NEDERLAND NL | Procedure: Openbaar | CPV: 45000000-7-Bouwwerkzaamheden</atom:content>
+      <atom:summary>Type publicatie: Vooraankondiging | Publicatiedatum: 12-12-2016 | Type opdracht: Werken | Sluitingsdatum: 13-03-2017 | Plaats van uitvoering: Groot-Amsterdam NL326, NEDERLAND NL | Procedure: Openbaar | CPV: 45000000-7-Bouwwerkzaamheden</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Project Management and Construction Management - Schiphol Capital Programme - Schiphol Nederland BV</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/3a6f67bbf6a0385946da958db2b72f16" />
+      <atom:updated>2016-12-12T16:00:01.522+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/3a6f67bbf6a0385946da958db2b72f16</atom:id>
+      <atom:published>2016-12-12T16:00:01.522+01:00</atom:published>
+      <atom:author>
+         <atom:name>Schiphol Nederland BV</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Kennisgeving van aanvullende informatie, informatie over een onvolledige procedure of rectificatie | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 17-04-2017 | Plaats van uitvoering: Groot-Amsterdam NL326, NEDERLAND NL | Procedure: Niet-openbaar | CPV: 71000000-8-Dienstverlening op het gebied van architectuur, bouwkunde, civiele techniek en inspectie</atom:content>
+      <atom:summary>Type publicatie: Kennisgeving van aanvullende informatie, informatie over een onvolledige procedure of rectificatie | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 17-04-2017 | Plaats van uitvoering: Groot-Amsterdam NL326, NEDERLAND NL | Procedure: Niet-openbaar | CPV: 71000000-8-Dienstverlening op het gebied van architectuur, bouwkunde, civiele techniek en inspectie</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Uitruklaarzen brandweer - Veiligheidsregio Noord- en Oost- Gelderland</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/b86607f9560eff357adc918db2b258ee" />
+      <atom:updated>2016-12-12T15:30:05.753+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/b86607f9560eff357adc918db2b258ee</atom:id>
+      <atom:published>2016-12-12T15:30:05.753+01:00</atom:published>
+      <atom:author>
+         <atom:name>Veiligheidsregio Noord- en Oost- Gelderland</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Leveringen | Sluitingsdatum: 13-02-2017 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 18800000-7-Schoeisel</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Leveringen | Sluitingsdatum: 13-02-2017 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 18800000-7-Schoeisel</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>market consultation tentsystem for militairy expeditionary operations - Defensie Materieel Organisatie</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/235594c1e98f791cc8b9facef09e3a3e" />
+      <atom:updated>2016-12-12T15:30:05.091+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/235594c1e98f791cc8b9facef09e3a3e</atom:id>
+      <atom:published>2016-12-12T15:30:05.091+01:00</atom:published>
+      <atom:author>
+         <atom:name>Defensie Materieel Organisatie</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Vooraankondiging | Publicatiedatum: 12-12-2016 | Type opdracht: Leveringen | Sluitingsdatum: 07-02-2017 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 39522530-1-Tenten</atom:content>
+      <atom:summary>Type publicatie: Vooraankondiging | Publicatiedatum: 12-12-2016 | Type opdracht: Leveringen | Sluitingsdatum: 07-02-2017 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 39522530-1-Tenten</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Opleidingen Bedrijfshulpverlening en EHBO - Gemeente Groningen</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/74f9af3930c08035e8834dd50538d235" />
+      <atom:updated>2016-12-12T15:30:04.468+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/74f9af3930c08035e8834dd50538d235</atom:id>
+      <atom:published>2016-12-12T15:30:04.468+01:00</atom:published>
+      <atom:author>
+         <atom:name>Gemeente Groningen</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum:  | Plaats van uitvoering: Overig Groningen NL113 | Procedure: Openbaar | CPV: 80550000-4-Diensten voor opleiding inzake veiligheid</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum:  | Plaats van uitvoering: Overig Groningen NL113 | Procedure: Openbaar | CPV: 80550000-4-Diensten voor opleiding inzake veiligheid</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Levering en onderhoud LC-MS systeem - Radboud Universitair Medisch Centrum</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/781f834d59e96dccc405a6196884dae3" />
+      <atom:updated>2016-12-12T15:30:03.668+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/781f834d59e96dccc405a6196884dae3</atom:id>
+      <atom:published>2016-12-12T15:30:03.668+01:00</atom:published>
+      <atom:author>
+         <atom:name>Radboud Universitair Medisch Centrum</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging in het geval van vrijwillige transparantie vooraf | Publicatiedatum: 12-12-2016 | Type opdracht: Leveringen | Sluitingsdatum: 01-12-2016 | Plaats van uitvoering: NEDERLAND NL, Arnhem/Nijmegen NL226 | Procedure: Onderhandeling zonder bekendmaking | CPV: 38433100-0-Massaspectrometers</atom:content>
+      <atom:summary>Type publicatie: Aankondiging in het geval van vrijwillige transparantie vooraf | Publicatiedatum: 12-12-2016 | Type opdracht: Leveringen | Sluitingsdatum: 01-12-2016 | Plaats van uitvoering: NEDERLAND NL, Arnhem/Nijmegen NL226 | Procedure: Onderhandeling zonder bekendmaking | CPV: 38433100-0-Massaspectrometers</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>31090726: A27/A1 Utrecht Noord â€“ Knooppunt Eemnes â€“ Aansluiting Bunschoten-Spakenburg - Rijkswaterstaat Grote Projecten en Onderhoud (GPO)</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/f8d1f1b03e9322955f8cd6699da6f4fa" />
+      <atom:updated>2016-12-12T15:30:01.539+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/f8d1f1b03e9322955f8cd6699da6f4fa</atom:id>
+      <atom:published>2016-12-12T15:30:01.539+01:00</atom:published>
+      <atom:author>
+         <atom:name>Rijkswaterstaat Grote Projecten en Onderhoud (GPO)</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Werken | Sluitingsdatum: 14-06-2016 | Plaats van uitvoering: Utrecht NL310 | Procedure: Concurrentiegerichte dialoog | CPV: 45233100-0-Bouwwerkzaamheden voor hoofdwegen en wegen</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Werken | Sluitingsdatum: 14-06-2016 | Plaats van uitvoering: Utrecht NL310 | Procedure: Concurrentiegerichte dialoog | CPV: 45233100-0-Bouwwerkzaamheden voor hoofdwegen en wegen</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Specialist Grondexploitaties - Gemeente Noordoostpolder</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/3bb6180c317a6b161e258f11acb6252d" />
+      <atom:updated>2016-12-12T15:18:51.170+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/3bb6180c317a6b161e258f11acb6252d</atom:id>
+      <atom:published>2016-12-12T15:18:51.170+01:00</atom:published>
+      <atom:author>
+         <atom:name>Gemeente Noordoostpolder</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 23-12-2016 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 79000000-4-Zakelijke dienstverlening: juridisch, marketing, consulting, drukkerij en beveiliging</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 23-12-2016 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 79000000-4-Zakelijke dienstverlening: juridisch, marketing, consulting, drukkerij en beveiliging</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>BD 10100020448  Procesbegeleider Sourcing IV/ICT Diensten - Ministerie van Veiligheid en Justitie/Dienstencentrum/Inkoopuitvoeringscentrum VenJ Europees aanbesteden/contractmanagement</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/99953b8687bbf2bcb2fa2eee18a74866" />
+      <atom:updated>2016-12-12T15:15:01.513+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/99953b8687bbf2bcb2fa2eee18a74866</atom:id>
+      <atom:published>2016-12-12T15:15:01.513+01:00</atom:published>
+      <atom:author>
+         <atom:name>Ministerie van Veiligheid en Justitie/Dienstencentrum/Inkoopuitvoeringscentrum VenJ Europees aanbesteden/contractmanagement</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum:  | Plaats van uitvoering: NEDERLAND NL | Procedure: Niet-openbaar | CPV: 79620000-6-Diensten voor de terbeschikkingstelling van personeel, met inbegrip van tijdelijk personeel</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum:  | Plaats van uitvoering: NEDERLAND NL | Procedure: Niet-openbaar | CPV: 79620000-6-Diensten voor de terbeschikkingstelling van personeel, met inbegrip van tijdelijk personeel</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Raamovereenkomst Onderhoud Gazons 2017 en verder - Gemeente Krimpenerwaard</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/a98ba69970c776c5c902ecdb78e5319e" />
+      <atom:updated>2016-12-12T15:00:13.369+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/a98ba69970c776c5c902ecdb78e5319e</atom:id>
+      <atom:published>2016-12-12T15:00:13.369+01:00</atom:published>
+      <atom:author>
+         <atom:name>Gemeente Krimpenerwaard</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Vooraankondiging | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 15-02-2017 | Plaats van uitvoering: Zuid-Holland NL33, NEDERLAND NL | Procedure: Openbaar | CPV: 77310000-6-Beplanten en onderhouden van groengebieden</atom:content>
+      <atom:summary>Type publicatie: Vooraankondiging | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 15-02-2017 | Plaats van uitvoering: Zuid-Holland NL33, NEDERLAND NL | Procedure: Openbaar | CPV: 77310000-6-Beplanten en onderhouden van groengebieden</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Technisch mechanische werkzaamheden en aanverwante dienstverlening - Waterschap Scheldestromen</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/25b4a6508c1dae486abd9eac9ed96895" />
+      <atom:updated>2016-12-12T15:00:02.602+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/25b4a6508c1dae486abd9eac9ed96895</atom:id>
+      <atom:published>2016-12-12T15:00:02.602+01:00</atom:published>
+      <atom:author>
+         <atom:name>Waterschap Scheldestromen</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum:  | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 50000000-5-Reparatie- en onderhoudsdiensten</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum:  | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 50000000-5-Reparatie- en onderhoudsdiensten</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Raamovereenkomst Onderhoud Beplantingen 2017 en verder - Gemeente Krimpenerwaard</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/417b11bc6066e0011f482debba1d436e" />
+      <atom:updated>2016-12-12T15:00:01.656+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/417b11bc6066e0011f482debba1d436e</atom:id>
+      <atom:published>2016-12-12T15:00:01.656+01:00</atom:published>
+      <atom:author>
+         <atom:name>Gemeente Krimpenerwaard</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Vooraankondiging | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 15-02-2017 | Plaats van uitvoering: Zuid-Holland NL33, NEDERLAND NL | Procedure: Openbaar | CPV: 77310000-6-Beplanten en onderhouden van groengebieden</atom:content>
+      <atom:summary>Type publicatie: Vooraankondiging | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 15-02-2017 | Plaats van uitvoering: Zuid-Holland NL33, NEDERLAND NL | Procedure: Openbaar | CPV: 77310000-6-Beplanten en onderhouden van groengebieden</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Specialist Grondexploitaties - Gemeente Noordoostpolder</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/652c5a7b04f59515c5f725af9a2d0994" />
+      <atom:updated>2016-12-12T14:53:41.595+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/652c5a7b04f59515c5f725af9a2d0994</atom:id>
+      <atom:published>2016-12-12T14:53:41.595+01:00</atom:published>
+      <atom:author>
+         <atom:name>Gemeente Noordoostpolder</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Kennisgeving van aanvullende informatie, informatie over een onvolledige procedure of rectificatie | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 15-12-2016 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 79000000-4-Zakelijke dienstverlening: juridisch, marketing, consulting, drukkerij en beveiliging</atom:content>
+      <atom:summary>Type publicatie: Kennisgeving van aanvullende informatie, informatie over een onvolledige procedure of rectificatie | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 15-12-2016 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 79000000-4-Zakelijke dienstverlening: juridisch, marketing, consulting, drukkerij en beveiliging</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Bouw- en Woonrijpmaken Ackerswoude - gemeente Pijnacker-Nootdorp</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/3efa312baef3079e866d24014cdf7252" />
+      <atom:updated>2016-12-12T14:45:01.629+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/3efa312baef3079e866d24014cdf7252</atom:id>
+      <atom:published>2016-12-12T14:45:01.629+01:00</atom:published>
+      <atom:author>
+         <atom:name>gemeente Pijnacker-Nootdorp</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Werken | Sluitingsdatum: 21-10-2016 | Plaats van uitvoering: Agglomeratie 's-Gravenhage NL332, NEDERLAND NL | Procedure: Openbaar | CPV: 45000000-7-Bouwwerkzaamheden</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Werken | Sluitingsdatum: 21-10-2016 | Plaats van uitvoering: Agglomeratie 's-Gravenhage NL332, NEDERLAND NL | Procedure: Openbaar | CPV: 45000000-7-Bouwwerkzaamheden</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>HR Personeels- en salarissysteem - Hogeschool Inholland</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/154abd17373ee5fed86c63b8996fb98a" />
+      <atom:updated>2016-12-12T14:30:01.580+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/154abd17373ee5fed86c63b8996fb98a</atom:id>
+      <atom:published>2016-12-12T14:30:01.580+01:00</atom:published>
+      <atom:author>
+         <atom:name>Hogeschool Inholland</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 31-01-2017 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 48000000-8-Software en informatiesystemen</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 31-01-2017 | Plaats van uitvoering: NEDERLAND NL | Procedure: Openbaar | CPV: 48000000-8-Software en informatiesystemen</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Schoonmaak Binnensportaccommodaties - Gemeente Utrecht</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/bab37944a3476f45c089ae7cfbb0487c" />
+      <atom:updated>2016-12-12T14:15:01.506+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/bab37944a3476f45c089ae7cfbb0487c</atom:id>
+      <atom:published>2016-12-12T14:15:01.506+01:00</atom:published>
+      <atom:author>
+         <atom:name>Gemeente Utrecht</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 25-10-2016 | Plaats van uitvoering: Utrecht NL310, NEDERLAND NL | Procedure: Openbaar | CPV: 90900000-6-Schoonmaak- en afvalverwijderingsdiensten</atom:content>
+      <atom:summary>Type publicatie: Aankondiging van een gegunde opdracht | Publicatiedatum: 12-12-2016 | Type opdracht: Diensten | Sluitingsdatum: 25-10-2016 | Plaats van uitvoering: Utrecht NL310, NEDERLAND NL | Procedure: Openbaar | CPV: 90900000-6-Schoonmaak- en afvalverwijderingsdiensten</atom:summary>
+   </atom:entry>
+   <atom:entry>
+      <atom:title>Groslijst-systematiek - Binnen het fysieke domein voor GWW projecten - Gemeente Amsterdam, Ingenieursbureau</atom:title>
+      <atom:link href="https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/085809ebdefcc2bc9ef180363846da18" />
+      <atom:updated>2016-12-12T14:05:45.363+01:00</atom:updated>
+      <atom:id>https://www.tenderned.nl/tenderned-web/aankondiging/detail/samenvatting/akid/085809ebdefcc2bc9ef180363846da18</atom:id>
+      <atom:published>2016-12-12T14:05:45.363+01:00</atom:published>
+      <atom:author>
+         <atom:name>Gemeente Amsterdam, Ingenieursbureau</atom:name>
+      </atom:author>
+      <atom:content type="html">Type publicatie: Vooraankondiging | Publicatiedatum: 12-12-2016 | Type opdracht: Werken | Sluitingsdatum: 01-12-2020 | Plaats van uitvoering: Groot-Amsterdam NL326 | Procedure: Openbaar | CPV: 45000000-7-Bouwwerkzaamheden</atom:content>
+      <atom:summary>Type publicatie: Vooraankondiging | Publicatiedatum: 12-12-2016 | Type opdracht: Werken | Sluitingsdatum: 01-12-2020 | Plaats van uitvoering: Groot-Amsterdam NL326 | Procedure: Openbaar | CPV: 45000000-7-Bouwwerkzaamheden</atom:summary>
+   </atom:entry>
+</atom:feed>


### PR DESCRIPTION
This for the most part fixes #310.

However, it could be terribly confusing for end users because it only gets the detection right. People will still have to set `preprocess_xml = true` in order for it to parse the namespaced child elements properly.

Should we force pre-processing if a prefix is found? This could have unintended consequences for others...