### PR TITLE
Added YARD for documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 .ruby-version
 Gemfile.lock
 doc/
+.yardoc/
 pkg/
 rdoc/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,10 @@
 AllCops:
   TargetRubyVersion: 2.1
 
-Documentation:
-  Enabled: false
+Style/Documentation:
+  Enabled: true
+  Exclude:
+    - 'spec/**/*'
 
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
+require 'yard'
 
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.verbose = false
@@ -7,6 +8,10 @@ end
 
 RuboCop::RakeTask.new(:rubocop) do |t|
   t.options = ['--display-cop-names']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.files   = ['lib/**/*.rb', '-', 'LICENSE']
 end
 
 task default: [:spec, :rubocop]

--- a/feedjira.gemspec
+++ b/feedjira.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'vcr'
+  s.add_development_dependency 'yard', '~> 0.9'
 end

--- a/lib/feedjira/core_ext/string.rb
+++ b/lib/feedjira/core_ext/string.rb
@@ -1,4 +1,4 @@
-class String
+class String # rubocop:disable Style/Documentation
   def sanitize!
     replace(sanitize)
   end

--- a/lib/feedjira/core_ext/time.rb
+++ b/lib/feedjira/core_ext/time.rb
@@ -1,7 +1,7 @@
 require 'time'
 require 'date'
 
-class Time
+class Time # rubocop:disable Style/Documentation
   # Parse a time string and convert it to UTC without raising errors.
   # Parses a flattened 14-digit time (YYYYmmddHHMMMSS) as UTC.
   #

--- a/lib/feedjira/date_time_utilities.rb
+++ b/lib/feedjira/date_time_utilities.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Style/Documentation
 module Feedjira
   module DateTimeUtilities
     # This is our date parsing heuristic.

--- a/lib/feedjira/date_time_utilities/date_time_language_parser.rb
+++ b/lib/feedjira/date_time_utilities/date_time_language_parser.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Style/Documentation
 module Feedjira
   module DateTimeUtilities
     class DateTimeLanguageParser

--- a/lib/feedjira/date_time_utilities/date_time_pattern_parser.rb
+++ b/lib/feedjira/date_time_utilities/date_time_pattern_parser.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Style/Documentation
 module Feedjira
   module DateTimeUtilities
     class DateTimePatternParser

--- a/lib/feedjira/feed.rb
+++ b/lib/feedjira/feed.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Style/Documentation
 module Feedjira
   class Feed
     def self.parse_with(parser, xml, &block)

--- a/lib/feedjira/feed_entry_utilities.rb
+++ b/lib/feedjira/feed_entry_utilities.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Style/Documentation
 module Feedjira
   module FeedEntryUtilities
     include Enumerable

--- a/lib/feedjira/feed_utilities.rb
+++ b/lib/feedjira/feed_utilities.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Style/Documentation
 module Feedjira
   module FeedUtilities
     UPDATABLE_ATTRIBUTES = %w(title feed_url url last_modified etag).freeze

--- a/lib/feedjira/parser.rb
+++ b/lib/feedjira/parser.rb
@@ -1,1 +1,1 @@
-module Feedjira::Parser; end
+module Feedjira::Parser; end # rubocop:disable Style/Documentation

--- a/lib/feedjira/parser/atom_youtube_entry.rb
+++ b/lib/feedjira/parser/atom_youtube_entry.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Style/Documentation
 module Feedjira
   module Parser
     class AtomYoutubeEntry

--- a/lib/feedjira/parser/google_docs_atom.rb
+++ b/lib/feedjira/parser/google_docs_atom.rb
@@ -1,5 +1,5 @@
 require File.expand_path('./atom', File.dirname(__FILE__))
-
+# rubocop:disable Style/Documentation
 module Feedjira
   module Parser
     class GoogleDocsAtom

--- a/lib/feedjira/parser/google_docs_atom_entry.rb
+++ b/lib/feedjira/parser/google_docs_atom_entry.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Style/Documentation
 module Feedjira
   module Parser
     class GoogleDocsAtomEntry

--- a/lib/feedjira/parser/itunes_rss_owner.rb
+++ b/lib/feedjira/parser/itunes_rss_owner.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Style/Documentation
 module Feedjira
   module Parser
     class ITunesRSSOwner

--- a/lib/feedjira/parser/podlove_chapter.rb
+++ b/lib/feedjira/parser/podlove_chapter.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Style/Documentation
 module Feedjira
   module Parser
     class PodloveChapter

--- a/lib/feedjira/preprocessor.rb
+++ b/lib/feedjira/preprocessor.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Style/Documentation
 module Feedjira
   class Preprocessor
     def initialize(xml)


### PR DESCRIPTION
Initial fix for #345

I've reenabled rubocop for documentation (even if it lacks of checking the single methods) and suppress warnings for undocumented modules and classes.

@HParker Could you pleas review the changes if it fit's our needs