### PR TITLE
Support configuration for parsers

### DIFF
--- a/lib/feedjira/configuration.rb
+++ b/lib/feedjira/configuration.rb
@@ -10,6 +10,7 @@ module Feedjira
     attr_accessor(
       :follow_redirect_limit,
       :logger,
+      :parsers,
       :request_timeout,
       :strip_whitespace,
       :user_agent
@@ -26,6 +27,14 @@ module Feedjira
       yield self
     end
 
+    # Reset Feedjira's configuration to defaults
+    #
+    # @example
+    #   Feedjira.reset_configuration!
+    def reset_configuration!
+      set_default_configuration
+    end
+
     # @private
     def self.extended(base)
       base.set_default_configuration
@@ -34,10 +43,11 @@ module Feedjira
     # @private
     def set_default_configuration
       self.follow_redirect_limit = 3
+      self.logger = default_logger
+      self.parsers = default_parsers
       self.request_timeout = 30
       self.strip_whitespace = false
       self.user_agent = "Feedjira #{Feedjira::VERSION}"
-      self.logger = default_logger
     end
 
     private
@@ -48,6 +58,19 @@ module Feedjira
         logger.progname = 'Feedjira'
         logger.level = Logger::WARN
       end
+    end
+
+    # @private
+    def default_parsers
+      [
+        Feedjira::Parser::RSSFeedBurner,
+        Feedjira::Parser::GoogleDocsAtom,
+        Feedjira::Parser::AtomYoutube,
+        Feedjira::Parser::AtomFeedBurner,
+        Feedjira::Parser::Atom,
+        Feedjira::Parser::ITunesRSS,
+        Feedjira::Parser::RSS
+      ]
     end
   end
 end

--- a/lib/feedjira/feed.rb
+++ b/lib/feedjira/feed.rb
@@ -23,15 +23,11 @@ module Feedjira
       end
 
       def feed_classes
-        @feed_classes ||= [
-          Feedjira::Parser::RSSFeedBurner,
-          Feedjira::Parser::GoogleDocsAtom,
-          Feedjira::Parser::AtomYoutube,
-          Feedjira::Parser::AtomFeedBurner,
-          Feedjira::Parser::Atom,
-          Feedjira::Parser::ITunesRSS,
-          Feedjira::Parser::RSS
-        ]
+        @feed_classes ||= Feedjira.parsers
+      end
+
+      def reset_parsers!
+        @feed_classes = nil
       end
 
       def add_common_feed_element(element_tag, options = {})

--- a/spec/feedjira/feed_spec.rb
+++ b/spec/feedjira/feed_spec.rb
@@ -224,8 +224,26 @@ describe Feedjira::Feed do
       parser = Feedjira::Feed.determine_feed_parser_for_xml xml
       expect(parser).to eq new_parser
 
-      # this is a hack so that this doesn't break the rest of the tests
-      Feedjira::Feed.feed_classes.reject! { |o| o == new_parser }
+      Feedjira::Feed.reset_parsers!
+    end
+  end
+
+  describe 'when parsers are configured' do
+    it 'does not use default parsers' do
+      xml = 'Atom asdf'
+      new_parser = Class.new do
+        def self.able_to_parse?(_)
+          true
+        end
+      end
+
+      Feedjira.configure { |config| config.parsers = [new_parser] }
+
+      parser = Feedjira::Feed.determine_feed_parser_for_xml(xml)
+      expect(parser).to eq(new_parser)
+
+      Feedjira.reset_configuration!
+      Feedjira::Feed.reset_parsers!
     end
   end
 end


### PR DESCRIPTION
This allows users to explicitly set the list of parsers that will be
used for parsing feeds.

This is a step towards #370 