### PR TITLE
Use the default adapter configured

### DIFF
--- a/lib/feedjira/feed.rb
+++ b/lib/feedjira/feed.rb
@@ -81,7 +81,7 @@ module Feedjira
       def connection(url)
         Faraday.new(url: url, headers: headers, request: request_options) do |conn|
           conn.use FaradayMiddleware::FollowRedirects, limit: Feedjira.follow_redirect_limit
-          conn.adapter :net_http
+          conn.adapter Faraday.default_adapter
         end
       end
       # rubocop:enable LineLength


### PR DESCRIPTION
if i understand correctly, the whole idea of faraday is to provide a common api over multiple http clients. 

so say, i'm using httpclient in my project, i would want feedjira to use httpclient as well. 

what i would do is to set the default_adapter `Faraday.default_adapter = :httpclient`.