### PR TITLE
Fixed setting values in 'url', 'feed_url' attributes in atom feeds

### DIFF
--- a/lib/feedjira/parser/atom_feed_burner.rb
+++ b/lib/feedjira/parser/atom_feed_burner.rb
@@ -17,6 +17,8 @@ module Feedjira
       elements :"atom10:link", as: :hubs, value: :href, with: { rel: 'hub' }
       elements :entry, as: :entries, class: AtomFeedBurnerEntry
 
+      attr_writer :url, :feed_url
+
       def self.able_to_parse?(xml)
         ((/Atom/ =~ xml) && (/feedburner/ =~ xml) && !(/\<rss|\<rdf/ =~ xml)) || false # rubocop:disable Metrics/LineLength
       end
@@ -24,13 +26,13 @@ module Feedjira
       # Feed url is <link> with type="text/html" if present,
       # <link> with no type attribute otherwise
       def url
-        @url_text_html || url_notype
+        @url || @url_text_html || @url_notype
       end
 
       # Feed feed_url is <link> with type="application/atom+xml" if present,
       # <atom10:link> with type="application/atom+xml" otherwise
       def feed_url
-        @feed_url_link || feed_url_atom10_link
+        @feed_url || @feed_url_link || @feed_url_atom10_link
       end
 
       def self.preprocess(xml)

--- a/spec/feedjira/parser/atom_feed_burner_spec.rb
+++ b/spec/feedjira/parser/atom_feed_burner_spec.rb
@@ -54,6 +54,18 @@ module Feedjira::Parser
     it 'should parse entries' do
       expect(@feed.entries.size).to eq 5
     end
+
+    it 'should change url' do
+      new_url = 'http://some.url.com'
+      expect{@feed.url=new_url}.not_to raise_error
+      expect(@feed.url).to eq new_url
+    end
+
+    it 'should change feed_url' do
+      new_url = 'http://some.url.com'
+      expect{@feed.feed_url=new_url}.not_to raise_error
+      expect(@feed.feed_url).to eq new_url
+    end
   end
 
   describe 'parsing alternate style feeds' do
@@ -84,6 +96,18 @@ module Feedjira::Parser
 
     it 'should parse entries' do
       expect(@feed.entries.size).to eq 3
+    end
+
+    it 'should change url' do
+      new_url = 'http://some.url.com'
+      expect{@feed.url=new_url}.not_to raise_error
+      expect(@feed.url).to eq new_url
+    end
+
+    it 'should change feed_url' do
+      new_url = 'http://some.url.com'
+      expect{@feed.feed_url=new_url}.not_to raise_error
+      expect(@feed.feed_url).to eq new_url
     end
   end
 

--- a/spec/feedjira/parser/atom_feed_burner_spec.rb
+++ b/spec/feedjira/parser/atom_feed_burner_spec.rb
@@ -57,13 +57,13 @@ module Feedjira::Parser
 
     it 'should change url' do
       new_url = 'http://some.url.com'
-      expect{@feed.url=new_url}.not_to raise_error
+      expect{ @feed.url = new_url }.not_to raise_error
       expect(@feed.url).to eq new_url
     end
 
     it 'should change feed_url' do
       new_url = 'http://some.url.com'
-      expect{@feed.feed_url=new_url}.not_to raise_error
+      expect{ @feed.feed_url = new_url }.not_to raise_error
       expect(@feed.feed_url).to eq new_url
     end
   end
@@ -100,13 +100,13 @@ module Feedjira::Parser
 
     it 'should change url' do
       new_url = 'http://some.url.com'
-      expect{@feed.url=new_url}.not_to raise_error
+      expect{ @feed.url = new_url }.not_to raise_error
       expect(@feed.url).to eq new_url
     end
 
     it 'should change feed_url' do
       new_url = 'http://some.url.com'
-      expect{@feed.feed_url=new_url}.not_to raise_error
+      expect{ @feed.feed_url = new_url }.not_to raise_error
       expect(@feed.feed_url).to eq new_url
     end
   end

--- a/spec/feedjira/parser/atom_feed_burner_spec.rb
+++ b/spec/feedjira/parser/atom_feed_burner_spec.rb
@@ -57,13 +57,13 @@ module Feedjira::Parser
 
     it 'should change url' do
       new_url = 'http://some.url.com'
-      expect{ @feed.url = new_url }.not_to raise_error
+      expect { @feed.url = new_url }.not_to raise_error
       expect(@feed.url).to eq new_url
     end
 
     it 'should change feed_url' do
       new_url = 'http://some.url.com'
-      expect{ @feed.feed_url = new_url }.not_to raise_error
+      expect { @feed.feed_url = new_url }.not_to raise_error
       expect(@feed.feed_url).to eq new_url
     end
   end
@@ -100,13 +100,13 @@ module Feedjira::Parser
 
     it 'should change url' do
       new_url = 'http://some.url.com'
-      expect{ @feed.url = new_url }.not_to raise_error
+      expect { @feed.url = new_url }.not_to raise_error
       expect(@feed.url).to eq new_url
     end
 
     it 'should change feed_url' do
       new_url = 'http://some.url.com'
-      expect{ @feed.feed_url = new_url }.not_to raise_error
+      expect { @feed.feed_url = new_url }.not_to raise_error
       expect(@feed.feed_url).to eq new_url
     end
   end


### PR DESCRIPTION
Fixes https://github.com/feedjira/feedjira/issues/376

Adds back the ability to set values to "url" and "feed_url" attributes of AtomFeedBurner instances, that was removed in PR https://github.com/feedjira/feedjira/pull/366/files