### PR TITLE
Splat default_adapter

### DIFF
--- a/lib/feedjira/feed.rb
+++ b/lib/feedjira/feed.rb
@@ -81,7 +81,7 @@ module Feedjira
       def connection(url)
         Faraday.new(url: url, headers: headers, request: request_options) do |conn|
           conn.use FaradayMiddleware::FollowRedirects, limit: Feedjira.follow_redirect_limit
-          conn.adapter Faraday.default_adapter
+          conn.adapter(*Faraday.default_adapter)
         end
       end
       # rubocop:enable LineLength


### PR DESCRIPTION
This fixes #374. `#default_adapter` might have arguments, which needs to be passed into `#adapter(key, *args)`, so we need to splat here.