### PR TITLE
Add attributes to JSON Feed classes

### DIFF
--- a/lib/feedjira/parser/json_feed.rb
+++ b/lib/feedjira/parser/json_feed.rb
@@ -13,10 +13,11 @@ module Feedjira
         new(JSON.parse(json))
       end
 
-      attr_reader :version, :title, :url, :feed_url, :description,
+      attr_reader :json, :version, :title, :url, :feed_url, :description,
         :expired, :entries
 
       def initialize(json)
+        @json = json
         @version = json.fetch("version")
         @title = json.fetch("title")
         @url = json.fetch("home_page_url", nil)

--- a/lib/feedjira/parser/json_feed_item.rb
+++ b/lib/feedjira/parser/json_feed_item.rb
@@ -5,7 +5,7 @@ module Feedjira
       include FeedEntryUtilities
 
       attr_reader :json, :entry_id, :url, :external_url, :title, :content, :summary,
-        :published, :updated, :image, :banner_image, :author
+        :published, :updated, :image, :banner_image, :author, :categories
 
       def initialize(json)
         @json = json
@@ -20,6 +20,7 @@ module Feedjira
         @published = parse_published(json.fetch("date_published", nil))
         @updated = parse_updated(json.fetch("date_modified", nil))
         @author = author_name(json.fetch("author", nil))
+        @categories = json.fetch("tags", [])
       end
 
       private

--- a/lib/feedjira/parser/json_feed_item.rb
+++ b/lib/feedjira/parser/json_feed_item.rb
@@ -4,10 +4,11 @@ module Feedjira
     class JSONFeedItem
       include FeedEntryUtilities
 
-      attr_reader :entry_id, :url, :external_url, :title, :content, :summary,
+      attr_reader :json, :entry_id, :url, :external_url, :title, :content, :summary,
         :published, :updated, :image, :banner_image, :author
 
       def initialize(json)
+        @json = json
         @entry_id = json.fetch("id")
         @url = json.fetch("url")
         @external_url = json.fetch("external_url", nil)

--- a/spec/feedjira/parser/json_feed_item_spec.rb
+++ b/spec/feedjira/parser/json_feed_item_spec.rb
@@ -47,17 +47,19 @@ describe Feedjira::Parser::JSONFeedItem do
     expected_fields = %w(
       author
       banner_image
+      categories
       content
       entry_id
       external_url
       image
+      json
       published
       summary
       title
       updated
       url
     )
-    expect(all_fields.sort).to eq expected_fields
+    expect(all_fields).to match_array expected_fields
   end
 
   it "should support checking if a field exists in the entry" do


### PR DESCRIPTION
The JSON Feed format defines many other attributes than are defined in the JSONFeed/JSONFeedItem classes, so it is desirable to give full access to those via the `json` accessor.

Also, the "tags" element defined in JSON Feed should correspond to the `categories` accessor that is common to other feed item classes.