### PR TITLE
Support for parsing new iTunes podcasting tags

### DIFF
--- a/lib/feedjira/parser/itunes_rss.rb
+++ b/lib/feedjira/parser/itunes_rss.rb
@@ -31,6 +31,7 @@ module Feedjira
       element :"itunes:explicit", as: :itunes_explicit
       element :"itunes:complete", as: :itunes_complete
       element :"itunes:keywords", as: :itunes_keywords
+      element :"itunes:type", as: :itunes_type
 
       # New URL for the podcast feed
       element :"itunes:new_feed_url", as: :itunes_new_feed_url

--- a/lib/feedjira/parser/itunes_rss_item.rb
+++ b/lib/feedjira/parser/itunes_rss_item.rb
@@ -24,6 +24,10 @@ module Feedjira
       element :"itunes:image", value: :href, as: :itunes_image
       element :"itunes:isClosedCaptioned", as: :itunes_closed_captioned
       element :"itunes:order", as: :itunes_order
+      element :"itunes:season", as: :itunes_season
+      element :"itunes:episode", as: :itunes_episode
+      element :"itunes:title", as: :itunes_title
+      element :"itunes:episodeType", as: :itunes_episode_type
 
       # If summary is not present, use the description tag
       element :"itunes:summary", as: :itunes_summary

--- a/spec/feedjira/parser/itunes_rss_item_spec.rb
+++ b/spec/feedjira/parser/itunes_rss_item_spec.rb
@@ -12,6 +12,10 @@ describe Feedjira::Parser::ITunesRSSItem do
     expect(@item.title).to eq "Shake Shake Shake Your Spices"
   end
 
+  it "should parse the itunes title" do
+    expect(@item.itunes_title).to eq "Shake Shake Shake Your Spices"
+  end
+
   it "should parse the author" do
     expect(@item.itunes_author).to eq "John Doe"
   end
@@ -23,6 +27,18 @@ describe Feedjira::Parser::ITunesRSSItem do
   it "should parse the summary" do
     summary = "This week we talk about salt and pepper shakers, comparing and contrasting pour rates, construction materials, and overall aesthetics. Come and join the party!" # rubocop:disable Metrics/LineLength
     expect(@item.itunes_summary).to eq summary
+  end
+
+  it "should parse the itunes season" do
+    expect(@item.itunes_season).to eq "1"
+  end
+
+  it "should parse the itunes episode number" do
+    expect(@item.itunes_episode).to eq "3"
+  end
+
+  it "should parse the itunes episode type" do
+    expect(@item.itunes_episode_type).to eq "full"
   end
 
   it "should parse the enclosure" do

--- a/spec/feedjira/parser/itunes_rss_spec.rb
+++ b/spec/feedjira/parser/itunes_rss_spec.rb
@@ -95,6 +95,10 @@ module Feedjira::Parser
       ]
     end
 
+    it "should parse the itunes type" do
+      expect(@feed.itunes_type).to eq "episodic"
+    end
+
     it "should parse the summary" do
       summary = "All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our Podcast in the iTunes Music Store" # rubocop:disable Metrics/LineLength
       expect(@feed.itunes_summary).to eq summary

--- a/spec/sample_feeds/itunes.xml
+++ b/spec/sample_feeds/itunes.xml
@@ -9,6 +9,7 @@
 <copyright>&#x2117; &amp; &#xA9; 2005 John Doe &amp; Family</copyright>
 <lastBuildDate>Sat, 07 Sep 2002 09:42:31 GMT</lastBuildDate>
 <ttl>60</ttl>
+<itunes:type>episodic</itunes:type>
 <itunes:subtitle>A show about everything</itunes:subtitle>
 <itunes:new-feed-url>http://example.com/new.xml</itunes:new-feed-url>
 <itunes:author>John Doe</itunes:author>
@@ -39,6 +40,10 @@
 </itunes:category>
 <item>
 <title>Shake Shake Shake Your Spices</title>
+<itunes:title>Shake Shake Shake Your Spices</itunes:title>
+<itunes:episodeType>full</itunes:episodeType>
+<itunes:season>1</itunes:season>
+<itunes:episode>3</itunes:episode>
 <itunes:author>John Doe</itunes:author>
 <itunes:subtitle>A short primer on table spices</itunes:subtitle>
 <itunes:summary>This week we talk about salt and pepper shakers, comparing and contrasting pour rates, construction materials, and overall aesthetics. Come and join the party!</itunes:summary>
@@ -55,6 +60,10 @@
  
 <item>
 <title>Socket Wrench Shootout</title>
+<itunes:title>Socket Wrench Shootout</itunes:title>
+<itunes:episodeType>full</itunes:episodeType>
+<itunes:season>1</itunes:season>
+<itunes:episode>2</itunes:episode>
 <itunes:author>Jane Doe</itunes:author>
 <itunes:subtitle>Comparing socket wrenches is fun!</itunes:subtitle>
 <itunes:summary>This week we talk about metric vs. old english socket wrenches. Which one is better? Do you really need both? Get all of your answers here.</itunes:summary>
@@ -68,6 +77,10 @@
  
 <item>
 <title>Red, Whine, &amp; Blue</title>
+<itunes:title>Red, Whine, &amp; Blue</itunes:title>
+<itunes:episodeType>full</itunes:episodeType>
+<itunes:season>1</itunes:season>
+<itunes:episode>1</itunes:episode>
 <itunes:author>Various</itunes:author>
 <itunes:subtitle>Red + Blue != Purple</itunes:subtitle>
 <itunes:summary>This week we talk about surviving in a Red state if you are a Blue person. Or vice versa.</itunes:summary>


### PR DESCRIPTION
iOS 11 will have support for new podcast tags. Let's parse 'em!

http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf