### PR TITLE
Check for images in the thumbnail element before content

### DIFF
--- a/lib/feedjira/parser/atom_entry.rb
+++ b/lib/feedjira/parser/atom_entry.rb
@@ -12,6 +12,7 @@ module Feedjira
       element :content
       element :summary
 
+      element :"media:thumbnail", as: :image, value: :url
       element :"media:content", as: :image, value: :url
       element :enclosure, as: :image, value: :href
 

--- a/lib/feedjira/parser/atom_feed_burner_entry.rb
+++ b/lib/feedjira/parser/atom_feed_burner_entry.rb
@@ -13,6 +13,7 @@ module Feedjira
       element :summary
       element :content
 
+      element :"media:thumbnail", as: :image, value: :url
       element :"media:content", as: :image, value: :url
       element :enclosure, as: :image, value: :href
 

--- a/lib/feedjira/parser/rss_entry.rb
+++ b/lib/feedjira/parser/rss_entry.rb
@@ -13,6 +13,7 @@ module Feedjira
       element :"content:encoded", as: :content
       element :description, as: :summary
 
+      element :"media:thumbnail", as: :image, value: :url
       element :"media:content", as: :image, value: :url
       element :enclosure, as: :image, value: :url
 

--- a/lib/feedjira/parser/rss_feed_burner_entry.rb
+++ b/lib/feedjira/parser/rss_feed_burner_entry.rb
@@ -16,6 +16,7 @@ module Feedjira
       element :"content:encoded", as: :content
       element :description, as: :summary
 
+      element :"media:thumbnail", as: :image, value: :url
       element :"media:content", as: :image, value: :url
       element :enclosure, as: :image, value: :url
 


### PR DESCRIPTION
Simply just checks for thumbnail images in `media:thumbnail`, in most cases, before `media:content`

I could not find any relevant tests to update.