### PR TITLE
Add channel id element to AtomYoutubeEntry parser

### DIFF
--- a/lib/feedjira/parser/atom_youtube_entry.rb
+++ b/lib/feedjira/parser/atom_youtube_entry.rb
@@ -13,6 +13,7 @@ module Feedjira
       element :id, as: :entry_id
       element :updated
       element :"yt:videoId", as: :youtube_video_id
+      element :"yt:channelId", as: :youtube_channel_id
       element :"media:title", as: :media_title
       element :"media:content", as: :media_url, value: :url
       element :"media:content", as: :media_type, value: :type


### PR DESCRIPTION
Channel IDs can occur in entry elements received
through YouTube's PubSubHubbub push notifications.

https://developers.google.com/youtube/v3/guides/push_notifications