### PR TITLE
Check for presence of <feed> tag on feedburner/atom feeds.

### DIFF
--- a/lib/feedjira/parser/atom_feed_burner.rb
+++ b/lib/feedjira/parser/atom_feed_burner.rb
@@ -19,7 +19,7 @@ module Feedjira
       attr_writer :url, :feed_url
 
       def self.able_to_parse?(xml)
-        ((/Atom/ =~ xml) && (/feedburner/ =~ xml) && !(/\<rss|\<rdf/ =~ xml)) || false # rubocop:disable Metrics/LineLength
+        ((/<feed/ =~ xml) && (/Atom/ =~ xml) && (/feedburner/ =~ xml) && !(/\<rss|\<rdf/ =~ xml)) || false # rubocop:disable Metrics/LineLength
       end
 
       # Feed url is <link> with type="text/html" if present,


### PR DESCRIPTION
I came across [a site](https://2ality.com/) that Feedjira miss-identifies as being able to parse as a `Feedjira::Parser::AtomFeedBurner` feed.

The regex for `AtomFeedBurner` only check for the presence of the strings "Atom" and "feedburner" which might be too easy for a non-feed to satisfy. This adds the requirement of also needing a `<feed` tag.
