### PR TITLE
Make `#title` of Atom entry classes always return a plain text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@
   * `Feedjira::Feed.parse` has moved to `Feedjira.parse`
   * `Feedjira::Feed.fetch_and_parse` has been removed. See README examples for
       how to request XML and parse.
+  * `title` of Atom entry classes always return a plain text even in case the entry has a title of the HTML or XML type. [#423][] (@knu)
 
 * General
   * Drop support for Ruby 2.1
 
 * Enhancements
-  * `title` of Atom entry classes always return a plain text even in case the entry has a title of the HTML or XML type.  `raw_title` and `title_type` are added to Atom entry classes. [#423][] (@knu)
+  * `raw_title` and `title_type` are added to Atom entry classes. [#423][] (@knu)
 
 ## 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@
   * `Feedjira::Feed.parse` has moved to `Feedjira.parse`
   * `Feedjira::Feed.fetch_and_parse` has been removed. See README examples for
       how to request XML and parse.
+
 * General
   * Drop support for Ruby 2.1
+
+* Enhancements
+  * `title` of Atom entry classes always return a plain text even in case the entry has a title of the HTML or XML type.  `raw_title` and `title_type` are added to Atom entry classes. [#423][] (@knu)
 
 ## 2.1.1
 

--- a/lib/feedjira/atom_entry_utilities.rb
+++ b/lib/feedjira/atom_entry_utilities.rb
@@ -4,7 +4,13 @@ module Feedjira
   module AtomEntryUtilities
     def self.included(mod)
       mod.class_exec do
-        element :title
+        element :title, as: :raw_title, with: { type: "html" }
+        element :title, as: :raw_title, with: { type: "xhtml" }
+        element :title, as: :raw_title, with: { type: "xml" }
+        element :title, as: :title, with: { type: "text" }
+        element :title, as: :title, with: { type: nil }
+        element :title, as: :title_type, value: :type
+
         element :name, as: :author
         element :content
         element :summary
@@ -26,6 +32,16 @@ module Feedjira
 
         elements :link, as: :links, value: :href
       end
+    end
+
+    def title
+      @title ||=
+        case @raw_title
+        when String
+          Loofah.fragment(@raw_title).xpath("normalize-space(.)")
+        else
+          @title
+        end
     end
 
     def url

--- a/spec/feedjira/parser/atom_entry_spec.rb
+++ b/spec/feedjira/parser/atom_entry_spec.rb
@@ -78,6 +78,7 @@ describe Feedjira::Parser::AtomEntry do
       published
       summary
       title
+      title_type
       updated
       url
     )

--- a/spec/feedjira/parser/atom_spec.rb
+++ b/spec/feedjira/parser/atom_spec.rb
@@ -75,7 +75,9 @@ module Feedjira
         feed = Atom.parse sample_atom_xhtml_feed
         entry = feed.entries.first
 
-        expect(entry.title).to match(/\<i/)
+        expect(entry.raw_title).to match(/\<i/)
+        expect(entry.title).to eq("Sentry Calming Collar for dogs")
+        expect(entry.title_type).to eq("xhtml")
         expect(entry.summary).to match(/\<b/)
         expect(entry.content).to match(/\A\<p/)
       end


### PR DESCRIPTION
Some Atom feeds provide entry titles in a non-plain text format like HTML, but you normally wouldn't expect that and there is no way to tell if an entry title returned from a Feedjira entry object is actually in HTML.

This PR makes `title()` methods of Atom entry classes always return a plain text by stripping off markups when the title element has a type of (X)HTML/XML.  For accessing raw contents, the new
methods `title_type` and `raw_title` are added.

P.S. This PR is marked as WIP because the work is based on #422 which aims to avoid duplicating the same code to all Atom entry classes.