### PR TITLE
RSS: assign media and enclosure values to corresponding accessors

### DIFF
--- a/lib/feedjira/rss_entry_utilities.rb
+++ b/lib/feedjira/rss_entry_utilities.rb
@@ -26,9 +26,12 @@ module Feedjira
         element :guid, as: :entry_id
         element :"dc:identifier", as: :dc_identifier
 
-        element :"media:thumbnail", as: :image, value: :url
-        element :"media:content", as: :image, value: :url
-        element :enclosure, as: :image, value: :url
+        element :"media:thumbnail", value: :url, as: :media_thumbnail
+        element :"media:content", value: :url, as: :media_content
+
+        element :enclosure, value: :length, as: :enclosure_length
+        element :enclosure, value: :type, as: :enclosure_type
+        element :enclosure, value: :url, as: :enclosure_url
 
         elements :category, as: :categories
       end


### PR DESCRIPTION
https://github.com/feedjira/feedjira/issues/428

This would be a breaking change.

Please reject this PR if the previous code has a good reason for the way it was.

--

Previously, RSS entry utilities assigns enclosure url to image, overwriting media thumbnail and content:

https://github.com/feedjira/feedjira/blob/master/lib/feedjira/rss_entry_utilities.rb#L31

However, iTunes RSS maps directly to enclosure_url:

https://github.com/feedjira/feedjira/blob/master/lib/feedjira/parser/itunes_rss_item.rb#L31