### PR TITLE
Test on last 3 major versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.2
-  - 2.3
-  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - jruby-9
   - ruby-head
 


### PR DESCRIPTION
We don't have an official "Supported versions" list, but I know that 2.2-2.4 is not correct anymore. I am guessing it is best to test the last 3 major versions for now. That should get us all ruby versions back to 2017, which seems appropriately cautious for now.