### PR TITLE
Add alias for managingEditor element

### DIFF
--- a/lib/feedjira/parser/itunes_rss.rb
+++ b/lib/feedjira/parser/itunes_rss.rb
@@ -20,7 +20,7 @@ module Feedjira
       element :language
       element :lastBuildDate, as: :last_built
       element :link, as: :url
-      element :managingEditor
+      element :managingEditor, as: :managing_editor
       element :rss, as: :version, value: :version
       element :title
       element :ttl


### PR DESCRIPTION
Adding alias will provide more rube style way off checking content of managingEditor
issue: #439 