### PR TITLE
Run CI using GitHub Actions

### DIFF
--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+        ruby: [2.5, 2.6, 2.7, head, jruby]
+        handler: [nokogiri, ox, oga]
+        exclude:
+          - { ruby: jruby, handler: ox }
+
+    name: >-
+      ${{matrix.os}}-ruby${{matrix.ruby}}-${{matrix.handler}}
+    runs-on: ${{matrix.os}}-latest
+    continue-on-error: ${{matrix.ruby == 'head' || matrix.ruby == 'jruby'}}
+    env:
+      HANDLER: ${{matrix.handler}}
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Set up ruby and bundle
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{matrix.ruby}}
+          bundler-cache: true
+
+      - name: Run rake
+        run: |
+          bundle exec rake


### PR DESCRIPTION
Now Travis CI builds won't run as quickly as before and jobs tend to be stuck in the queue for hours.
I'm not sure how it's going to be after the migration from travis-ci.org to travis-ci.com, but I think it's time for us to take action and prepare for service degradation.

GitHub Actions offers 2,000 free build minutes per month for OSS projects, but since we have a 5x3 matrix our usage may exceed the limit, in which case we'll need to split the matrix and use both GitHub and Travis CI.