### PR TITLE
Fix required ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,11 +4,6 @@ AllCops:
   TargetRubyVersion: 2.5
   NewCops: enable
 
-
-Gemspec/RequiredRubyVersion:
-  Exclude:
-    - 'feedjira.gemspec'
-
 # Offense count: 3
 # Configuration parameters: IgnoredMethods.
 Metrics/AbcSize:

--- a/feedjira.gemspec
+++ b/feedjira.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  s.required_ruby_version = ">=2.2"
+  s.required_ruby_version = ">=2.5"
 
   s.add_dependency "loofah",             ">= 2.3.1"
   s.add_dependency "sax-machine",        ">= 1.0"


### PR DESCRIPTION
This makes the required Ruby version in the gemspec match the version configured for RuboCop, and the set of Rubies tested in CI.

Fixes #447.