### PR TITLE
Remove unused VCR dependency

### DIFF
--- a/feedjira.gemspec
+++ b/feedjira.gemspec
@@ -37,6 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "faraday"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rubocop"
-  s.add_development_dependency "vcr"
   s.add_development_dependency "yard"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,14 +2,8 @@
 
 require File.expand_path("#{File.dirname(__FILE__)}/../lib/feedjira")
 require "sample_feeds"
-require "vcr"
 
 SAXMachine.handler = ENV["HANDLER"].to_sym if ENV["HANDLER"]
-
-VCR.configure do |config|
-  config.cassette_library_dir = "fixtures/vcr_cassettes"
-  config.hook_into :faraday
-end
 
 RSpec.configure do |c|
   c.include SampleFeeds


### PR DESCRIPTION
VCR is no longer actually used in the specs, since the feching portion of Feedjira has been removed.