### PR TITLE
Atom url parsing

### DIFF
--- a/lib/feedjira/parser/atom.rb
+++ b/lib/feedjira/parser/atom.rb
@@ -20,7 +20,7 @@ module Feedjira
       end
 
       def url
-        @url || (links - [feed_url]).last || links.last
+        @url || (links - [feed_url]).last
       end
 
       def self.preprocess(xml)

--- a/lib/feedjira/parser/atom.rb
+++ b/lib/feedjira/parser/atom.rb
@@ -23,10 +23,6 @@ module Feedjira
         @url || (links - [feed_url]).last || links.last
       end
 
-      def feed_url
-        @feed_url ||= links.first
-      end
-
       def self.preprocess(xml)
         Preprocessor.new(xml).to_xml
       end

--- a/spec/feedjira/parser/atom_spec.rb
+++ b/spec/feedjira/parser/atom_spec.rb
@@ -111,6 +111,12 @@ module Feedjira
         feed = Atom.parse xml
         expect(feed.feed_url).to be_nil
       end
+
+      it "should not parse links with the rel='self' attribute as url" do
+        xml = load_sample "atom_simple_single_entry_link_self.xml"
+        feed = Atom.parse xml
+        expect(feed.url).to be_nil
+      end
     end
   end
 end

--- a/spec/feedjira/parser/atom_spec.rb
+++ b/spec/feedjira/parser/atom_spec.rb
@@ -93,7 +93,7 @@ module Feedjira
       end
     end
 
-    describe "parsing url and feed url based on rel attribute" do
+    describe "parsing url and feed_url" do
       before :each do
         @feed = Atom.parse(sample_atom_middleman_feed)
       end
@@ -102,8 +102,14 @@ module Feedjira
         expect(@feed.url).to eq "http://feedjira.com/blog"
       end
 
-      it "should parse feed url" do
+      it "should parse feed_url" do
         expect(@feed.feed_url).to eq "http://feedjira.com/blog/feed.xml"
+      end
+
+      it "should not parse links without the rel='self' attribute as feed_url" do
+        xml = load_sample "atom_simple_single_entry.xml"
+        feed = Atom.parse xml
+        expect(feed.feed_url).to be_nil
       end
     end
   end

--- a/spec/sample_feeds.rb
+++ b/spec/sample_feeds.rb
@@ -3,6 +3,7 @@
 module SampleFeeds
   FEEDS = {
     sample_atom_feed: "AmazonWebServicesBlog.xml",
+    sample_atom_simple: "atom_simple_single_entry.xml",
     sample_atom_middleman_feed: "FeedjiraBlog.xml",
     sample_atom_xhtml_feed: "pet_atom.xml",
     sample_atom_feed_line_breaks: "AtomFeedWithSpacesAroundEquals.xml",

--- a/spec/sample_feeds.rb
+++ b/spec/sample_feeds.rb
@@ -4,6 +4,7 @@ module SampleFeeds
   FEEDS = {
     sample_atom_feed: "AmazonWebServicesBlog.xml",
     sample_atom_simple: "atom_simple_single_entry.xml",
+    sample_atom_simple_link_self: "atom_simple_single_entry_link_self.xml",
     sample_atom_middleman_feed: "FeedjiraBlog.xml",
     sample_atom_xhtml_feed: "pet_atom.xml",
     sample_atom_feed_line_breaks: "AtomFeedWithSpacesAroundEquals.xml",

--- a/spec/sample_feeds/atom_simple_single_entry.xml
+++ b/spec/sample_feeds/atom_simple_single_entry.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example Feed</title>
+  <link href="http://example.org/"/>
+  <updated>2003-12-13T18:30:02Z</updated>
+  <author>
+    <name>John Doe</name>
+  </author>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+  <entry>
+    <title>Atom-Powered Robots Run Amok</title>
+    <link href="http://example.org/2003/12/13/atom03"/>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+    <summary>Some text.</summary>
+  </entry>
+</feed>

--- a/spec/sample_feeds/atom_simple_single_entry_link_self.xml
+++ b/spec/sample_feeds/atom_simple_single_entry_link_self.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example Feed</title>
+  <link href="http://example.org/atom.xml" rel="self"/>
+  <updated>2003-12-13T18:30:02Z</updated>
+  <author>
+    <name>John Doe</name>
+  </author>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+  <entry>
+    <title>Atom-Powered Robots Run Amok</title>
+    <link href="http://example.org/2003/12/13/atom03"/>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+    <summary>Some text.</summary>
+  </entry>
+</feed>


### PR DESCRIPTION
Hello and thanks for building and maintaining feedjira!

I noticed that when an Atom feed only include one link, e.g. `<link href="http://example.org/"/>` in the top-level element, it will automatically be parsed as both `url` _and_ `feed_url`. This PR changes `feed_url` to only look for links with the `rel="self"`-attribute and removes the fallback for `url` to the last link in the document.

### Parsing of `feed_url`

The current way to look for `feed_url` dates back to 2009 (https://github.com/feedjira/feedjira/commit/d0854f46469248aa2d6ef4d35bef4f8222278f77) and mentions that this will fix links that "don't confirm to the standard" (note that the way the parser looks for `feed_url` has changed since then (https://github.com/feedjira/feedjira/commit/4b4d803bfec9c2e7964d96f64d9c4f861614143c). I think falling back to the first link is too naive since a link to the feed isn't strictly necessary. It's recommended though, but then with the `rel="self"`-attribute.

> atom:feed elements SHOULD contain one atom:link element with a rel attribute value of "self". This is the preferred URI for retrieving Atom Feed Documents representing this Atom feed.

Quoted from https://datatracker.ietf.org/doc/html/rfc4287#section-4.1.1

### Parsing of `url`

The current fallback for `url` is also inaccurate imho, since that doesn't exclude any self-links which obviously isn't meant to be interpreted as an "alternate" link.

> atom:link elements MAY have a "rel" attribute that indicates the link relation type. If the "rel" attribute is not present, the link element MUST be interpreted as if the link relation type is "alternate".

Quoted from https://datatracker.ietf.org/doc/html/rfc4287#section-4.2.7.2

### Wrap up

I don't think that these changes will have any significant impact on current usage of this library, since most Atom feeds will include both alternate and self links. But this will fix those rare cases when there are only one link present.

I'm happy to write a changelog message if this PR is accepted.