### PR TITLE
Coverage: add tests for `core_ext/time`

### DIFF
--- a/lib/feedjira/core_ext/time.rb
+++ b/lib/feedjira/core_ext/time.rb
@@ -16,12 +16,12 @@ class Time
     if datetime.is_a?(Time)
       datetime.utc
     elsif datetime.respond_to?(:to_datetime)
-      datetime.to_datetime.utc
-    elsif datetime.respond_to? :to_s
+      datetime.to_time.utc
+    else
       parse_string_safely datetime.to_s
     end
   rescue StandardError => e
-    Feedjira.logger.debug { "Failed to parse time #{datetime}" }
+    Feedjira.logger.debug("Failed to parse time #{datetime}")
     Feedjira.logger.debug(e)
     nil
   end

--- a/spec/feedjira/core_ext/time_spec.rb
+++ b/spec/feedjira/core_ext/time_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Time do
+  describe "#parse_safely" do
+    it "returns the datetime in utc when given a Time" do
+      time = described_class.now
+
+      expect(described_class.parse_safely(time)).to eq(time.utc)
+    end
+
+    it "returns the datetime in utc when given a Date" do
+      date = Date.today
+
+      expect(described_class.parse_safely(date)).to eq(date.to_time.utc)
+    end
+
+    it "returns the datetime in utc when given a String" do
+      timestamp = "2016-01-01 00:00:00"
+
+      expect(described_class.parse_safely(timestamp)).to eq(described_class.parse(timestamp).utc)
+    end
+
+    it "returns nil when given an empty String" do
+      timestamp = ""
+
+      expect(described_class.parse_safely(timestamp)).to be_nil
+    end
+
+    it "returns the the datetime in utc given a 14-digit time" do
+      time = described_class.now.utc
+      timestamp = time.strftime("%Y%m%d%H%M%S")
+
+      expect(described_class.parse_safely(timestamp)).to eq(time.floor)
+    end
+
+    context "when given an invalid time string" do
+      it "returns nil" do
+        timestamp = "2016-51-51 00:00:00"
+
+        expect(described_class.parse_safely(timestamp)).to be_nil
+      end
+
+      it "logs an error" do
+        timestamp = "2016-51-51 00:00:00"
+
+        expect(Feedjira.logger)
+          .to receive(:debug).with("Failed to parse time #{timestamp}")
+        expect(Feedjira.logger)
+          .to receive(:debug).with(an_instance_of(ArgumentError))
+
+        described_class.parse_safely(timestamp)
+      end
+    end
+  end
+end

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -7,4 +7,4 @@ SimpleCov.start do
   add_filter "_spec.rb"
 end
 
-SimpleCov.minimum_coverage(line: 97, branch: 69)
+SimpleCov.minimum_coverage(line: 98, branch: 75)


### PR DESCRIPTION
This adds missing test coverage for `core_ext/time`. This also surfaced
a code issue with the second condition. Ruby `DateTime` does not
implement the `#utc` method so calling `datetime.to_datetime.utc`
actually raises an error. I removed this in favor of calling `.to_time`
on anything that responds to it.

```irb
> Date.today.to_datetime.utc
(irb):6:in `<main>': undefined method `utc' for #<DateTime: 2023-10-22T00:00:00+00:00 ((2460240j,0s,0n),+0s,2299161j)> (NoMethodError)
```