### PR TITLE
Coverage: add tests for Feed methods

### DIFF
--- a/spec/feedjira/feed_spec.rb
+++ b/spec/feedjira/feed_spec.rb
@@ -2,17 +2,8 @@
 
 require "spec_helper"
 
-class Hell < StandardError; end
-
-class FailParser
-  def self.parse(_xml)
-    yield "this parser always fails."
-    # on_failure.call
-  end
-end
-
 describe Feedjira::Feed do
-  describe "#add_common_feed_element" do
+  describe ".add_common_feed_element" do
     before(:all) do
       described_class.add_common_feed_element("generator")
     end
@@ -30,7 +21,25 @@ describe Feedjira::Feed do
     end
   end
 
-  describe "#add_common_feed_entry_element" do
+  describe ".add_common_feed_elements" do
+    before do
+      described_class.add_common_feed_elements(:foos)
+    end
+
+    it "parses the added element out of Atom feeds" do
+      expect(Feedjira.parse(sample_wfw_feed).foos).to eq []
+    end
+
+    it "parses the added element out of Atom Feedburner feeds" do
+      expect(Feedjira::Parser::Atom.new).to respond_to(:foos)
+    end
+
+    it "parses the added element out of RSS feeds" do
+      expect(Feedjira::Parser::RSS.new).to respond_to(:foos)
+    end
+  end
+
+  describe ".add_common_feed_entry_element" do
     before(:all) do
       tag = "wfw:commentRss"
       described_class.add_common_feed_entry_element tag, as: :comment_rss
@@ -47,6 +56,25 @@ describe Feedjira::Feed do
 
     it "parses the added element out of RSS feeds entries" do
       expect(Feedjira::Parser::RSSEntry.new).to respond_to(:comment_rss)
+    end
+  end
+
+  describe ".add_common_feed_entry_elements" do
+    before do
+      described_class.add_common_feed_entry_elements(:things)
+    end
+
+    it "parses the added element out of Atom feeds entries" do
+      entry = Feedjira.parse(sample_wfw_feed).entries.first
+      expect(entry.things).to eq []
+    end
+
+    it "parses the added element out of Atom Feedburner feeds entries" do
+      expect(Feedjira::Parser::AtomEntry.new).to respond_to(:things)
+    end
+
+    it "parses the added element out of RSS feeds entries" do
+      expect(Feedjira::Parser::RSSEntry.new).to respond_to(:things)
     end
   end
 end


### PR DESCRIPTION
This adds missing test coverage for `Feed.add_common_feed_elements` and
`Feed.add_common_feed_entry_elements`. I don't love these because they
only test the highest level, and they have side effects on the other
classes that will persist throughout the tests. Without digging into
`SAXMachine` internals, though, there's not much to do.
