### PR TITLE
Switch date parse error to debug

### DIFF
--- a/lib/feedjira/feed_entry_utilities.rb
+++ b/lib/feedjira/feed_entry_utilities.rb
@@ -11,8 +11,8 @@ module Feedjira
     def parse_datetime(string)
       DateTime.parse(string).feed_utils_to_gm_time
     rescue StandardError => e
-      Feedjira.logger.warn { "Failed to parse date #{string.inspect}" }
-      Feedjira.logger.warn(e)
+      Feedjira.logger.debug("Failed to parse date #{string.inspect}")
+      Feedjira.logger.debug(e)
       nil
     end
 

--- a/spec/feedjira_spec.rb
+++ b/spec/feedjira_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Feedjira do
       end
 
       it "does not fail if multiple published dates exist and some are unparseable" do
-        expect(described_class.logger).to receive(:warn).twice
+        expect(described_class.logger).to receive(:debug).twice
 
         feed = described_class.parse(sample_invalid_date_format_feed)
         expect(feed.title).to eq "Invalid date format feed"


### PR DESCRIPTION
Fix #395 (again). There are a couple of places we log out failures to
parse dates. This updates the *other* one to be `debug` log level.