### PR TITLE
Increasing slice limit regarding able_to_parse?

### DIFF
--- a/lib/feedjira.rb
+++ b/lib/feedjira.rb
@@ -70,7 +70,7 @@ module Feedjira
   #   parser = Feedjira.parser_for_xml(xml)
   #   parser.parse(xml)
   def parser_for_xml(xml)
-    start_of_doc = xml.slice(0, 2000)
+    start_of_doc = xml.slice(0, 4000)
     Feedjira.parsers.detect { |klass| klass.able_to_parse?(start_of_doc) }
   end
   module_function :parser_for_xml


### PR DESCRIPTION
Hello!

I encountered a feed that had a very long base64 encoded string from https://www.rss.style at the beginning of its RSS XML file.

The previous limit of 2000 characters was insufficient and in turn `able_to_parse?` always returned `false`.

This commit doubles that limit to 4000 characters, which was then sufficient to parse the feed (which otherwise was a valid RSS feed without issues).

I'm not sure, if this PR is a desired solution to this problem. Because this might still break if some other feed has an even longer run-up to the tag that determines parsability. Also, the `2000` characters limit might have been there for a reason!?

Happy to solve this differently, if there are any suggestions for improvement.

✌️