### PR TITLE
Removing start_of_doc slice limit altogether

### DIFF
--- a/lib/feedjira.rb
+++ b/lib/feedjira.rb
@@ -70,8 +70,7 @@ module Feedjira
   #   parser = Feedjira.parser_for_xml(xml)
   #   parser.parse(xml)
   def parser_for_xml(xml)
-    start_of_doc = xml.slice(0, 4000)
-    Feedjira.parsers.detect { |klass| klass.able_to_parse?(start_of_doc) }
+    Feedjira.parsers.detect { |klass| klass.able_to_parse?(xml) }
   end
   module_function :parser_for_xml
 end


### PR DESCRIPTION
To be able to parse all feeds, regardless whether they meet the criteria somewhat early in the document

Sample JSON feed, that has the determining version statement right at the end: https://aaronparecki.com/feed.json.

@mockdeep Sorry, here we go [again](https://github.com/feedjira/feedjira/pull/514). 😬 Not quite sure, if removing the character limit like this is feasible, but I thought I present this suggestion to you regardless. 😊