### PR TITLE
Add explicit logger dependency in gemspec for ruby 3.5+

### DIFF
--- a/feedjira.gemspec
+++ b/feedjira.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">=2.7"
 
+  s.add_dependency "logger", ">= 1.0", "< 2"
   s.add_dependency "loofah", ">= 2.3.1", "< 3"
   s.add_dependency "sax-machine", ">= 1.0", "< 2"
-  s.add_dependency "logger", ">= 1.0", "< 2"
 end


### PR DESCRIPTION
As for other gems in the past years, logger has been marked as no longer bundled with the standard library starting from ruby version 3.5: https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c

This indeed shows up as a warning on ruby 3.4:
> [...]/vendor/bundle/ruby/3.4.0/gems/feedjira-3.2.5/lib/feedjira.rb:6: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.

This PR adds an explicit dependency to logger in the gemspec, which should suppress the warning.