### PR TITLE
Coverage: add missing coverage for GoogleDocsAtom

### DIFF
--- a/spec/feedjira/parser/google_docs_atom_spec.rb
+++ b/spec/feedjira/parser/google_docs_atom_spec.rb
@@ -31,5 +31,41 @@ module Feedjira
         expect(@feed.entries.first).to be_a GoogleDocsAtomEntry
       end
     end
+
+    describe "#url" do
+      it "returns the url when set" do
+        feed = GoogleDocsAtom.new
+
+        feed.url = "http://exampoo.com/feed"
+
+        expect(feed.url).to eq "http://exampoo.com/feed"
+      end
+
+      it "returns the first link when not set" do
+        feed = GoogleDocsAtom.new
+
+        feed.links = ["http://exampoo.com/feed"]
+
+        expect(feed.url).to eq "http://exampoo.com/feed"
+      end
+    end
+
+    describe "#feed_url" do
+      it "returns the feed_url when set" do
+        feed = GoogleDocsAtom.new
+
+        feed.feed_url = "http://exampoo.com/feed"
+
+        expect(feed.feed_url).to eq "http://exampoo.com/feed"
+      end
+
+      it "returns the first link when not set" do
+        feed = GoogleDocsAtom.new
+
+        feed.links = ["http://exampoo.com/feed"]
+
+        expect(feed.feed_url).to eq "http://exampoo.com/feed"
+      end
+    end
   end
 end

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -7,4 +7,4 @@ SimpleCov.start do
   add_filter "_spec.rb"
 end
 
-SimpleCov.minimum_coverage(line: 98, branch: 75)
+SimpleCov.minimum_coverage(line: 99, branch: 77)


### PR DESCRIPTION
This adds missing test coverage for `GoogleDocsAtom#url` and
`#feed_url`.
