### PR TITLE
Coverage: remove condition in Preprocessor

### DIFF
--- a/lib/feedjira/preprocessor.rb
+++ b/lib/feedjira/preprocessor.rb
@@ -15,7 +15,7 @@ module Feedjira
 
     def process_content
       content_nodes.each do |node|
-        node.content = raw_html(node) unless node.cdata?
+        node.content = raw_html(node)
       end
     end
 


### PR DESCRIPTION
It looks like [`CDATA`][cd] is mutually exclusive from content nodes. The
method `content_nodes` searches for `content`, `summary`, and `title`,
which are all of [type "element"][el].

[cd]: https://github.com/sparklemotion/nokogiri/blob/d29828c83fbc7ace24419c1f2aa91a9a17745462/lib/nokogiri/xml/node.rb#L1339-L1341
[el]: https://github.com/sparklemotion/nokogiri/blob/d29828c83fbc7ace24419c1f2aa91a9a17745462/lib/nokogiri/xml/node.rb#L1390-L1392
