### PR TITLE
Amending Atom parser able_to_parse regex to also match the HTTPS variant of the xmlns attribute value

### DIFF
--- a/lib/feedjira/parser/atom.rb
+++ b/lib/feedjira/parser/atom.rb
@@ -17,7 +17,7 @@ module Feedjira
       element :icon
 
       def self.able_to_parse?(xml)
-        %r{<feed[^>]+xmlns\s?=\s?["'](http://www\.w3\.org/2005/Atom|http://purl\.org/atom/ns\#)["'][^>]*>} =~ xml
+        %r{<feed[^>]+xmlns\s?=\s?["'](https?://www\.w3\.org/2005/Atom|http://purl\.org/atom/ns\#)["'][^>]*>} =~ xml
       end
 
       def url


### PR DESCRIPTION
This enables parsing of such feeds. Example: https://www.miriamsuzanne.com/feed.atom.

--------

Hello again!

I found an Atom feed where `<feed xmlns="https://www.w3.org/2005/Atom">` included the *HTTPS* variant of the namespace. I believe this is valid, so I amended the regex to match both cases.

Do you want a test for this, too? Happy to add one, but I would probably add the whole feed (see above) as one more sample feed, and I wasn't sure about this.