### PR TITLE
Fix ITunesRSS.able_to_parse? false positive on CDATA content

### DIFF
--- a/lib/feedjira/parser/itunes_rss.rb
+++ b/lib/feedjira/parser/itunes_rss.rb
@@ -63,7 +63,8 @@ module Feedjira
       elements :item, as: :entries, class: ITunesRSSItem
 
       def self.able_to_parse?(xml)
-        %r{xmlns:itunes\s?=\s?["']http://www\.itunes\.com/dtds/podcast-1\.0\.dtd["']}i =~ xml
+        xml_without_cdata = xml.gsub(/<!\[CDATA\[.*?\]\]>/m, "")
+        %r{xmlns:itunes\s?=\s?["']http://www\.itunes\.com/dtds/podcast-1\.0\.dtd["']}i =~ xml_without_cdata
       end
     end
   end

--- a/spec/feedjira/parser/itunes_rss_spec.rb
+++ b/spec/feedjira/parser/itunes_rss_spec.rb
@@ -24,6 +24,10 @@ module Feedjira
       it "returns false for an rss feedburner feed" do
         expect(ITunesRSS).not_to be_able_to_parse(sample_rss_feed_burner_feed)
       end
+
+      it "returns false for an atom feed with xmlns:itunes inside CDATA" do
+        expect(ITunesRSS).not_to be_able_to_parse(sample_atom_with_itunes_in_cdata)
+      end
     end
 
     describe "parsing" do

--- a/spec/feedjira_spec.rb
+++ b/spec/feedjira_spec.rb
@@ -155,6 +155,12 @@ RSpec.describe Feedjira do
       expect(actual_parser).to eq described_class::Parser::ITunesRSS
     end
 
+    it "with an atom feed containing xmlns:itunes in CDATA it returns the Atom parser" do
+      xml = sample_atom_with_itunes_in_cdata
+      actual_parser = described_class.parser_for_xml(xml)
+      expect(actual_parser).to eq described_class::Parser::Atom
+    end
+
     context "when parsers are configured" do
       it "does not use default parsers" do
         xml = "Atom asdf"

--- a/spec/sample_feeds.rb
+++ b/spec/sample_feeds.rb
@@ -37,7 +37,8 @@ module SampleFeeds
     sample_invalid_date_format_feed: "InvalidDateFormat.xml",
     sample_rss_feed_permalinks: "Permalinks.xml",
     sample_rss_feed_with_a10_namespace: "a10.xml",
-    sample_rss_feed_with_comments: "RSSWithComments.xml"
+    sample_rss_feed_with_comments: "RSSWithComments.xml",
+    sample_atom_with_itunes_in_cdata: "AtomWithITunesInCDATA.xml"
   }.freeze
 
   FEEDS.each do |method, filename|

--- a/spec/sample_feeds/AtomWithITunesInCDATA.xml
+++ b/spec/sample_feeds/AtomWithITunesInCDATA.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Blog</title>
+  <link rel="alternate" href="https://example.com/" />
+  <id>tag:example.com,2024:blog</id>
+  <updated>2024-01-01T00:00:00Z</updated>
+  <entry>
+    <title>How to set up a podcast RSS feed</title>
+    <link href="https://example.com/post/1" />
+    <id>tag:example.com,2024:post-1</id>
+    <published>2024-01-01T00:00:00Z</published>
+    <content type="html"><![CDATA[
+      <p>Here is an example RSS feed:</p>
+      <pre><code>&lt;rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"&gt;</code></pre>
+    ]]></content>
+  </entry>
+</feed>


### PR DESCRIPTION
## Summary

- `ITunesRSS.able_to_parse?` matches `xmlns:itunes` namespace declaration anywhere in the XML, including inside CDATA sections
- When an Atom feed's `<content>` contains a code snippet with `xmlns:itunes` (e.g., a blog post explaining how to set up a podcast RSS feed), the feed is incorrectly detected as an iTunes RSS feed
- Since ITunesRSS has the highest priority in parser selection, this causes the Atom feed to be parsed with the wrong parser

## Fix

Strip CDATA sections from the XML before matching the `xmlns:itunes` namespace declaration.

```ruby
def self.able_to_parse?(xml)
  xml_without_cdata = xml.gsub(/<!\[CDATA\[.*?\]\]>/m, "")
  %r{xmlns:itunes\s?=\s?["']http://www\.itunes\.com/dtds/podcast-1\.0\.dtd["']}i =~ xml_without_cdata
end
```

## Test plan

- [x] Added spec: `ITunesRSS` returns false for an Atom feed with `xmlns:itunes` inside CDATA
- [x] Added spec: `parser_for_xml` selects the Atom parser for such feeds
- [x] All 369 existing specs pass
- [x] Line and branch coverage remain at 100%